### PR TITLE
Add build pipeline

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        export ACCEPT_EULA=Y
+        sudo apt-get update
+        python -m pip install --upgrade pip
+        sudo apt-get install -y python3-pip libgdal-dev locales
+        export CPLUS_INCLUDE_PATH=/usr/include/gdal
+        export C_INCLUDE_PATH=/usr/include/gdal
+        sudo apt-get install ca-certificates
+        export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+        pip install GDAL==2.2.3
+        pip install -e .
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8 . --max-line-length 120 --count  --show-source --statistics --exclude=scripts,tests
+    - name: Unit tests
+      run: |
+        export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+        ./scripts/code-coverage.sh
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-1
+    - name: Push zip to S3
+      run: |
+        echo $GITHUB_SHA > release
+        zip -r app.zip .
+        repo_slug=`echo $GITHUB_REPOSITORY | awk -F '/' '{print $2}'`
+        echo $repo_slug
+        aws s3 cp app.zip s3://arup-arup-ukimea-tcs-dev-test-code/$repo_slug.zip
+    - name: Send build success notification
+      if: success()
+      uses: rtCamp/action-slack-notify@v2.0.0
+      env:
+        SLACK_MESSAGE: ${{ github.repository }} build ${{ github.run_number }} launched by ${{ github.actor }} has succeeded
+        SLACK_TITLE: Build Success
+        SLACK_CHANNEL: city-modelling-feeds
+        SLACK_USERNAME: GitHub Build Bot
+        SLACK_ICON: https://slack-files2.s3-us-west-2.amazonaws.com/avatars/2017-12-19/288981919427_f45f04edd92902a96859_512.png
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    - name: Send build failure notification
+      if: failure()
+      uses: rtCamp/action-slack-notify@v2.0.0
+      env:
+        SLACK_COLOR: '#FF0000'
+        SLACK_MESSAGE: ${{ github.repository }} build ${{ github.run_number }} launched by ${{ github.actor }} has failed
+        SLACK_TITLE: Build Failure!
+        SLACK_CHANNEL: city-modelling-feeds
+        SLACK_USERNAME: GitHub Build Bot
+        SLACK_ICON: https://slack-files2.s3-us-west-2.amazonaws.com/avatars/2017-12-19/288981919427_f45f04edd92902a96859_512.png
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
- I wanted to see the build run in my branch and fix it there before opening a PR, but it looks like this has to be merged to master to enable actions pipelines, so may as well do that now 
- Not sure how the pip cache step will react to there being no `requirements.txt`; hopefully it just means no cache, rather than a failed build, but let's see
- I'm using the full rule set for `flake8`, which *will* fail the build for some trivial warnings, but I'm happy to see it fail and then fix it
- I will fix the `ppyproj` deprecation warnings in a different PR