### PR TITLE
backwards compatibility for missing `elem.text` values

### DIFF
--- a/genet/inputs_handler/matsim_reader.py
+++ b/genet/inputs_handler/matsim_reader.py
@@ -99,6 +99,7 @@ def read_link_attrib(elem, link_attribs):
     """
     d = elem.attrib
     if elem.text is None:
+        d['text'] = ''
         logging.warning(f"Elem {elem.attrib['name']} is being read as None.")
     elif (',' in elem.text) and elem.attrib['name'] != 'geometry':
         d['text'] = set(elem.text.split(','))

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -32,6 +32,8 @@ simplified_network = os.path.abspath(
 simplified_schedule = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "test_data", "simplified_network", "schedule.xml"))
 
+network_link_attrib_text_missing = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "test_data", "matsim", "network_link_attrib_text_missing.xml"))
 
 @pytest.fixture()
 def network1():
@@ -470,6 +472,12 @@ def test_reading_back_simplified_network():
             for k, v in attribs['attributes'].items():
                 if isinstance(v['text'], str):
                     assert not ',' in v['text']
+
+
+def test_network_with_missing_link_attribute_elem_text_is_read_and_able_to_save_again(tmpdir):
+    n = Network('epsg:27700')
+    n.read_matsim_network(network_link_attrib_text_missing)
+    n.write_to_matsim(tmpdir)
 
 
 def test_node_attribute_data_under_key_returns_correct_pd_series_with_nested_keys():

--- a/tests/test_data/matsim/network_link_attrib_text_missing.xml
+++ b/tests/test_data/matsim/network_link_attrib_text_missing.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE network SYSTEM "http://www.matsim.org/files/dtd/network_v2.dtd">
+<network>
+	<attributes>
+		<attribute name="crs" class="java.lang.String">{'init': 'epsg:27700'}</attribute>
+		<attribute name="simplified" class="java.lang.String">False</attribute>
+	</attributes>
+    <nodes>
+        <node id="21667818" x="528504.1342843144" y="182155.7435136598" >
+		</node>
+        <node id="25508485" x="528489.467895946" y="182206.20303669578" >
+		</node>
+    </nodes>
+    <links capperiod="01:00:00" effectivecellsize="7.5" effectivelanewidth="3.75">
+		<link id="1" from="25508485" to="21667818" length="52.765151087870265" freespeed="4.166666666666667" capacity="600.0" permlanes="1.0" oneway="1" modes="car,subway,metro,walk" >
+			<attributes>
+				<attribute name="osm:way:access" class="java.lang.String"/>
+				<attribute name="osm:way:highway" class="java.lang.String" >unclassified</attribute>
+				<attribute name="osm:way:id" class="java.lang.Long" >26997928</attribute>
+				<attribute name="geometry" class="java.lang.String"/>
+			</attributes>
+		</link>
+    </links>
+</network>


### PR DESCRIPTION
![Screenshot 2020-12-08 at 10 24 32](https://user-images.githubusercontent.com/36536946/101472065-fc16af00-393f-11eb-82fb-8259481d78cf.png)
![Screenshot 2020-12-08 at 10 24 49](https://user-images.githubusercontent.com/36536946/101472074-fde07280-393f-11eb-82c0-1f68139c6601.png)
