### PR TITLE
Empty attributes tidy-up

### DIFF
--- a/genet/inputs_handler/matsim_reader.py
+++ b/genet/inputs_handler/matsim_reader.py
@@ -80,7 +80,8 @@ def read_link(elem, g, u, v, node_id_mapping, link_id_mapping, link_attribs):
             if link_attribs['geometry']['text']:
                 attribs['geometry'] = spatial.decode_polyline_to_shapely_linestring(link_attribs['geometry']['text'])
                 del link_attribs['geometry']
-        attribs['attributes'] = link_attribs
+        if link_attribs:
+            attribs['attributes'] = link_attribs
 
     if g.has_edge(u, v):
         link_id_mapping[link_id]['multi_edge_idx'] = len(g[u][v])

--- a/tests/test_data/matsim/network_with_singular_geometry.xml
+++ b/tests/test_data/matsim/network_with_singular_geometry.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE network SYSTEM "http://www.matsim.org/files/dtd/network_v2.dtd">
+<network>
+    <nodes>
+        <node id="21667818" x="528504.1342843144" y="182155.7435136598" >
+		</node>
+        <node id="25508485" x="528489.467895946" y="182206.20303669578" >
+		</node>
+    </nodes>
+    <links capperiod="01:00:00" effectivecellsize="7.5" effectivelanewidth="3.75">
+		<link id="1" from="25508485" to="21667818" length="52.765151087870265" freespeed="4.166666666666667" capacity="600.0" permlanes="1.0" oneway="1" modes="car" >
+			<attributes>
+				<attribute name="geometry" class="java.lang.String">_ibE_seK_ibE_ibE_ibE_ibE</attribute>
+			</attributes>
+		</link>
+		<link id="2" from="25508485" to="21667818" length="52.765151087870265" freespeed="4.166666666666667" capacity="600.0" permlanes="1.0" oneway="1" modes="car" >
+			<attributes>
+				<attribute name="geometry" class="java.lang.String">_ibE_seK_ibE_ibE_ibE_ibE</attribute>
+			</attributes>
+		</link>
+    </links>
+</network>

--- a/tests/test_inputs_handler_matsim_reader.py
+++ b/tests/test_inputs_handler_matsim_reader.py
@@ -16,6 +16,8 @@ matsim_output_network = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "test_data", "matsim", "matsim_output_network.xml"))
 pt2matsim_network_with_geometry_file = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "test_data", "matsim", "network_with_geometry.xml"))
+pt2matsim_network_with_singular_geometry_file = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "test_data", "matsim", "network_with_singular_geometry.xml"))
 pt2matsim_schedule_file = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "test_data", "matsim", "schedule.xml"))
 
@@ -269,6 +271,30 @@ def test_reading_network_with_geometry_attributes():
 
     n = Network('epsg:27700')
     n.read_matsim_network(pt2matsim_network_with_geometry_file)
+
+    assert_semantically_equal(dict(n.links()), correct_links)
+
+
+def test_reading_network_with_singular_geometry_attribute_cleans_up_empty_attributes_dict():
+    correct_links = {
+        '1': {
+            'id': "1", 'from': "25508485", 'to': "21667818", 'length': 52.765151087870265,
+            's2_from': 5221390301001263407, 's2_to': 5221390302696205321,
+            'freespeed': 4.166666666666667, 'capacity': 600.0, 'permlanes': 1.0, 'oneway': "1",
+            'geometry': LineString([(1, 2), (2, 3), (3, 4)]),
+            'modes': {'car'}
+        },
+        '2': {
+            'id': "2", 'from': "25508485", 'to': "21667818", 'length': 52.765151087870265,
+            's2_from': 5221390301001263407, 's2_to': 5221390302696205321,
+            'freespeed': 4.166666666666667, 'capacity': 600.0, 'permlanes': 1.0, 'oneway': "1",
+            'geometry': LineString([(1, 2), (2, 3), (3, 4)]),
+            'modes': {'car'}
+        }
+    }
+
+    n = Network('epsg:27700')
+    n.read_matsim_network(pt2matsim_network_with_singular_geometry_file)
 
     assert_semantically_equal(dict(n.links()), correct_links)
 


### PR DESCRIPTION
Some puma (PT) links only have geometry saved as link attributes in matsim network, i.e.
```xml
<link id="2" from="25508485" to="21667818" length="52.765151087870265" freespeed="4.166666666666667" capacity="600.0" permlanes="1.0" oneway="1" modes="car" >
  <attributes>
    <attribute name="geometry" class="java.lang.String">_ibE_seK_ibE_ibE_ibE_ibE</attribute>
  </attributes>
```
Genet moves these geometries to main link attributes (because geometry is used for different processes and easier to work with when not nested). This PR tidies up those attributes that would have been left empty as a result of moving the geometry to main link data dictionary. Empty attributes resulted in the following message at save time
![Screenshot 2020-12-09 at 10 26 28](https://user-images.githubusercontent.com/36536946/101618341-c76f2a00-3a09-11eb-9bca-70c779526c9e.png)
These messages are gone following the fix
![Screenshot 2020-12-09 at 10 26 40](https://user-images.githubusercontent.com/36536946/101618400-d950cd00-3a09-11eb-9257-d931c17a7006.png)

The test (which relies on new test data) which reproduces the problem, before fix and after:
![Screenshot 2020-12-09 at 10 23 04](https://user-images.githubusercontent.com/36536946/101618490-f4bbd800-3a09-11eb-9391-9e2de396dfea.png)
![Screenshot 2020-12-09 at 10 24 09](https://user-images.githubusercontent.com/36536946/101618503-f9808c00-3a09-11eb-9c91-5bb6974c5373.png)
