### PR TITLE
Google directions api uses GeNet's own simplification methods

### DIFF
--- a/genet/core.py
+++ b/genet/core.py
@@ -53,7 +53,7 @@ class Network:
         :param other:
         :return:
         """
-        if self.graph.graph['simplified'] != other.graph.graph['simplified']:
+        if self.is_simplified() != other.is_simplified():
             raise RuntimeError('You cannot add simplified and non-simplified networks together')
 
         # consolidate coordinate systems
@@ -158,11 +158,14 @@ class Network:
             self.transformer = None
 
     def simplify(self, no_processes=1):
-        if self.graph.graph["simplified"]:
+        if self.is_simplified():
             raise RuntimeError('This network has already been simplified. You cannot simplify the graph twice.')
         simplification.simplify_graph(self, no_processes)
         # mark graph as having been simplified
         self.graph.graph["simplified"] = True
+
+    def is_simplified(self):
+        return self.graph.graph["simplified"]
 
     def node_attribute_summary(self, data=False):
         """

--- a/genet/utils/google_directions.py
+++ b/genet/utils/google_directions.py
@@ -83,21 +83,23 @@ def make_request(origin_attributes, destination_attributes, key, traffic):
 
 def generate_requests(n):
     """
-    Generates two dictionaries, both of them have keys that describe a pair of nodes for which we need to request
-    directions from Google directions API
+    Generates a dictionary describing pairs of nodes for which we need to request
+    directions from Google directions API.
     :param n: genet.Network
     :return:
     """
     if n.is_simplified():
+        logging.info('Generating Google Directions API requests for a simplified network.')
         return _generate_requests_for_simplified_network(n)
     else:
+        logging.info('Generating Google Directions API requests for a non-simplified network.')
         return _generate_requests_for_non_simplified_network(n)
 
 
 def _generate_requests_for_non_simplified_network(n):
     """
-    Generates two dictionaries, both of them have keys that describe a pair of nodes for which we need to request
-    directions from Google directions API. For non-simplified network n
+    Generates a dictionary describing pairs of nodes for which we need to request
+    directions from Google directions API. For a non-simplified network n
     :param n: genet.Network
     :return:
     """
@@ -122,19 +124,19 @@ def _generate_requests_for_non_simplified_network(n):
 
 def _generate_requests_for_simplified_network(n):
     """
-    Generates two dictionaries, both of them have keys that describe a pair of nodes for which we need to request
-    directions from Google directions API. For non-simplified network n
+    Generates a dictionary describing pairs of nodes for which we need to request
+    directions from Google directions API. For a simplified network n
     :param n: genet.Network
     :return:
     """
-    all_paths = graph_operations.extract_links_on_edge_attributes(
+    links = graph_operations.extract_links_on_edge_attributes(
         network=n,
         conditions={'modes': 'car'},
         mixed_dtypes=True
     )
 
     api_requests = {}
-    for path in all_paths:
+    for path in links:
         request_nodes = (n.link(path)['from'], n.link(path)['to'])
         api_requests[request_nodes] = {
             'path_nodes': request_nodes,
@@ -142,6 +144,7 @@ def _generate_requests_for_simplified_network(n):
             'destination': n.node(request_nodes[1])
         }
         try:
+            # TODO change projection
             api_requests[request_nodes]['path_polyline'] = spatial.encode_shapely_linestring_to_polyline(
                 n.link(path)['geometry'])
         except KeyError:

--- a/genet/utils/google_directions.py
+++ b/genet/utils/google_directions.py
@@ -60,8 +60,8 @@ def read_saved_api_results(file_path):
     for key in json_dump:
         try:
             json_dump[key] = ast.literal_eval(json_dump[key])
-        except (ValueError, TypeError):
-            logging.warning(str(key) + ' not processed')
+        except (ValueError, TypeError) as e:
+            logging.warning(f'{str(key)} not processed due to {e}')
             continue
         api_requests[(json_dump[key]['path_nodes'][0], json_dump[key]['path_nodes'][-1])] = json_dump[key]
     return api_requests

--- a/genet/utils/google_directions.py
+++ b/genet/utils/google_directions.py
@@ -47,25 +47,22 @@ def send_requests_for_network(n, request_number_threshold: int, output_dir, traf
     return api_requests
 
 
-def read_saved_api_results(output_dir):
+def read_saved_api_results(file_path):
     """
-    Read parsed Google Directions API requests in output_dir
-    :param output_dir: output directory where the google directions api requests were saved as JSON
+    Read parsed Google Directions API requests in `file_path` JSON file
+    :param file_path: path to the JSON file where the google directions api requests were saved
     :return:
     """
     api_requests = {}
-    for file in os.listdir(output_dir):
-        if file.endswith(".json"):
-            response = os.path.join(output_dir, file)
-            with open(response, 'rb') as handle:
-                json_dump = json.load(handle)
-            for key in json_dump:
-                try:
-                    json_dump[key] = ast.literal_eval(json_dump[key])
-                except (ValueError, TypeError):
-                    logging.warning(str(key)+' not processed')
-                    continue
-                api_requests[(json_dump[key]['path_nodes'][0], json_dump[key]['path_nodes'][-1])] = json_dump[key]
+    with open(file_path, 'rb') as handle:
+        json_dump = json.load(handle)
+    for key in json_dump:
+        try:
+            json_dump[key] = ast.literal_eval(json_dump[key])
+        except (ValueError, TypeError):
+            logging.warning(str(key)+' not processed')
+            continue
+        api_requests[(json_dump[key]['path_nodes'][0], json_dump[key]['path_nodes'][-1])] = json_dump[key]
     return api_requests
 
 

--- a/genet/utils/spatial.py
+++ b/genet/utils/spatial.py
@@ -25,6 +25,15 @@ def encode_shapely_linestring_to_polyline(linestring):
     return polyline.encode(linestring.coords)
 
 
+def swap_x_y_in_linestring(linestring):
+    """
+    swaps x with y in a shapely linestring,e.g. from LineString([(1,2), (3,4)]) to LineString([(2,1), (4,3)])
+    :param linestring: shapely.geometry.LineString
+    :return: shapely.geometry.LineString
+    """
+    return LineString((p[1], p[0]) for p in linestring.coords)
+
+
 def decode_polyline_to_shapely_linestring(_polyline):
     """
     :param _polyline: google encoded polyline

--- a/tests/test_utils_google_directions.py
+++ b/tests/test_utils_google_directions.py
@@ -16,7 +16,7 @@ from tests.fixtures import assert_semantically_equal, assert_logging_warning_cau
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 example_google_speed_data = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "test_data", "example_google_speed_data"))
+    os.path.join(os.path.dirname(__file__), "test_data", "example_google_speed_data", "api_requests.json"))
 
 
 @pytest.fixture()

--- a/tests/test_utils_google_directions.py
+++ b/tests/test_utils_google_directions.py
@@ -308,7 +308,6 @@ def test_send_requests_for_road_network(mocker, tmpdir, generated_request, googl
                                                              **{'request': Future(), 'timestamp': 12345}}})
     mocker.patch.object(Future, 'result', return_value=google_directions_api_response)
 
-
     n = Network('epsg:27700')
     google_directions.send_requests_for_network(n, 10, tmpdir)
     google_directions.generate_requests.assert_called_once_with(n)
@@ -376,23 +375,54 @@ def test_generating_requests_on_non_simplified_graphs():
 
 def test_generating_requests_on_simplified_graphs():
     n = Network('epsg:27700')
-    n.add_link('0', 1, 3, attribs={'modes': ['car'], 'geometry': LineString([(1,2), (1,2), (1,2)])})
-    n.add_link('3', 5, 3, attribs={'modes': ['car'], 'geometry': LineString([(1,2), (1,2), (1,2)])})
+    n.add_link('0', 1, 3, attribs={'modes': ['car'],
+                                   'geometry': LineString([(528915.9309752393, 181899.48948011652),
+                                                           (528888.1581643537, 181892.3086225874),
+                                                           (528780.3405144282, 181859.84184561518),
+                                                           (528780.3405144282, 181859.84184561518)])})
+    n.add_link('3', 5, 3, attribs={'modes': ['car'],
+                                   'geometry': LineString([(528888.1581643537, 181892.3086225874),
+                                                           (528915.9309752393, 181899.48948011652),
+                                                           (528780.3405144282, 181859.84184561518)])})
     n.add_link('4', 1, 10, attribs={'modes': ['car']})
+    n.add_link('5', 10, 1, attribs={'modes': ['walk']})
     n.graph.graph["simplified"] = True
 
-    for node in n.graph.nodes:
-        n.apply_attributes_to_node(node, {'lat': 1, 'lon': 2})
+    n.apply_attributes_to_nodes({1: {'x': 528915.9309752393, 'y': 181899.48948011652},
+                                 3: {'x': 528780.3405144282, 'y': 181859.84184561518},
+                                 5: {'x': 528888.1581643537, 'y': 181892.3086225874},
+                                 10: {'x': 528780.3405144282, 'y': 181892.3086225874},
+                                 })
+
+    n.apply_attributes_to_nodes({1: {'lon': -0.14327038749428384, 'lat': 51.52130909540579},
+                                 3: {'lon': -0.14523808749533396, 'lat': 51.520983695405526},
+                                 5: {'lon': -0.14367308749449406, 'lat': 51.52125089540575},
+                                 10: {'lon': -0.14522623292591474, 'lat': 51.521275465129236}})
 
     api_requests = google_directions.generate_requests(n)
 
-    assert_semantically_equal(api_requests, {
-        (1, 10): {'path_nodes': (1, 10), 'path_polyline': '_ibE_seK??', 'origin': {'lat': 1, 'lon': 2},
-                  'destination': {'lat': 1, 'lon': 2}},
-        (1, 3): {'path_nodes': (1, 3), 'path_polyline': '_ibE_seK????', 'origin': {'lat': 1, 'lon': 2},
-                 'destination': {'lat': 1, 'lon': 2}},
-        (5, 3): {'path_nodes': (5, 3), 'path_polyline': '_ibE_seK????', 'origin': {'lat': 1, 'lon': 2},
-                 'destination': {'lat': 1, 'lon': 2}}})
+    assert_semantically_equal(api_requests, {(1, 3): {'path_nodes': (1, 3),
+                                                      'origin': {'x': 528915.9309752393, 'y': 181899.48948011652,
+                                                                 'lon': -0.14327038749428384, 'lat': 51.52130909540579},
+                                                      'destination': {'x': 528780.3405144282, 'y': 181859.84184561518,
+                                                                      'lon': -0.14523808749533396,
+                                                                      'lat': 51.520983695405526},
+                                                      'path_polyline': 'ewmyHl~ZJnAt@xH??'},
+                                             (5, 3): {'path_nodes': (5, 3),
+                                                      'origin': {'x': 528888.1581643537, 'y': 181892.3086225874,
+                                                                 'lon': -0.14367308749449406, 'lat': 51.52125089540575},
+                                                      'destination': {'x': 528780.3405144282, 'y': 181859.84184561518,
+                                                                      'lon': -0.14523808749533396,
+                                                                      'lat': 51.520983695405526},
+                                                      'path_polyline': 'yvmyH|`[KoA`AhK'},
+                                             (1, 10): {'path_nodes': (1, 10),
+                                                       'origin': {'x': 528915.9309752393, 'y': 181899.48948011652,
+                                                                  'lon': -0.14327038749428384,
+                                                                  'lat': 51.52130909540579},
+                                                       'destination': {'x': 528780.3405144282, 'y': 181892.3086225874,
+                                                                       'lon': -0.14522623292591474,
+                                                                       'lat': 51.521275465129236},
+                                                       'path_polyline': 'ewmyHl~ZDfK'}})
 
 
 def test_sending_requests(mocker, google_directions_api_response):

--- a/tests/test_utils_google_directions.py
+++ b/tests/test_utils_google_directions.py
@@ -5,6 +5,7 @@ import logging
 import time
 import os
 import sys
+from shapely.geometry import LineString
 from requests.models import Response
 from concurrent.futures._base import Future
 from requests_futures.sessions import FuturesSession
@@ -370,6 +371,27 @@ def test_generating_requests_on_non_simplified_graphs():
         (1, 3): {'path_nodes': [1, 2, 3], 'path_polyline': '_ibE_seK????', 'origin': {'lat': 1, 'lon': 2},
                  'destination': {'lat': 1, 'lon': 2}},
         (5, 3): {'path_nodes': [5, 4, 3], 'path_polyline': '_ibE_seK????', 'origin': {'lat': 1, 'lon': 2},
+                 'destination': {'lat': 1, 'lon': 2}}})
+
+
+def test_generating_requests_on_simplified_graphs():
+    n = Network('epsg:27700')
+    n.add_link('0', 1, 3, attribs={'modes': ['car'], 'geometry': LineString([(1,2), (1,2), (1,2)])})
+    n.add_link('3', 5, 3, attribs={'modes': ['car'], 'geometry': LineString([(1,2), (1,2), (1,2)])})
+    n.add_link('4', 1, 10, attribs={'modes': ['car']})
+    n.graph.graph["simplified"] = True
+
+    for node in n.graph.nodes:
+        n.apply_attributes_to_node(node, {'lat': 1, 'lon': 2})
+
+    api_requests = google_directions.generate_requests(n)
+
+    assert_semantically_equal(api_requests, {
+        (1, 10): {'path_nodes': (1, 10), 'path_polyline': '_ibE_seK??', 'origin': {'lat': 1, 'lon': 2},
+                  'destination': {'lat': 1, 'lon': 2}},
+        (1, 3): {'path_nodes': (1, 3), 'path_polyline': '_ibE_seK????', 'origin': {'lat': 1, 'lon': 2},
+                 'destination': {'lat': 1, 'lon': 2}},
+        (5, 3): {'path_nodes': (5, 3), 'path_polyline': '_ibE_seK????', 'origin': {'lat': 1, 'lon': 2},
                  'destination': {'lat': 1, 'lon': 2}}})
 
 

--- a/tests/test_utils_spatial.py
+++ b/tests/test_utils_spatial.py
@@ -1,6 +1,7 @@
 import s2sphere
 from genet.utils import spatial
 from tests.fixtures import *
+from shapely.geometry import LineString
 
 
 def test_decode_polyline_to_s2_points():
@@ -9,6 +10,10 @@ def test_decode_polyline_to_s2_points():
                         5221390693026247929, 5221390693047976565, 5221390685911708669, 5221390685910265239,
                         5221390683049158953, 5221390683157459293, 5221390683301132839, 5221390683277381201,
                         5221390683276573369, 5221390683274586647]
+
+
+def test_swaping_x_y_in_linestring():
+    assert spatial.swap_x_y_in_linestring(LineString([(1,2), (3,4), (5,6)])) == LineString([(2,1), (4,3), (6,5)])
 
 
 def test_compute_average_proximity_to_polyline():


### PR DESCRIPTION
Google direction methods now differentiate between networks that have the simplified tag and not. If a network is not simplified, they now use GeNet's own methods (previously osmnx).

As a bonus, I changed the [read method ](https://github.com/arup-group/genet/compare/google-directions-api-with-own-simplification#diff-462244c575997d50c1cb3baeec5285e1b7dc38b3df72e8a1430e0a848f6b55ddR51) to expect a path to a single file, as that's what the rest of the code produces. Just in case someone passes a folder with a number of different json files, which is likely, could be different json files generated by running the google requests at different times, that way you can have them all in the same folder. I think it's cleaner and less convoluted.

Annoyingly, google encoded polylines (when decoded) are of the form `[(lat, lon)]` whereas our geometries are of the format compatible with kepler: `[(lon, lat)]`, so needed to add an extra method and step to swap them 😿  (the polylines are used when more than one route is returned from google directions API (each has an encoded google polyline); the proximity of original request to each possible route determines which one gets picked for the speed computation)