### PR TITLE
Fix simplifications script's help message (LAB-990)

### DIFF
--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -8,7 +8,8 @@ from genet.utils.persistence import ensure_dir
 
 
 if __name__ == '__main__':
-    arg_parser = argparse.ArgumentParser(description='Reproject a MATSim network')
+    arg_parser = argparse.ArgumentParser(description='Simplify a MATSim network by removing '
+                                                     'intermediate links from paths')
 
     arg_parser.add_argument('-n',
                             '--network',
@@ -35,7 +36,7 @@ if __name__ == '__main__':
 
     arg_parser.add_argument('-od',
                             '--output_dir',
-                            help='Output directory for the reprojected network',
+                            help='Output directory for the simplified network',
                             required=True)
 
     args = vars(arg_parser.parse_args())


### PR DESCRIPTION
See https://arupdigital.atlassian.net/browse/LAB-990

**After this change**:
```
$ python scripts/simplify_network.py --help
usage: simplify_network.py [-h] -n NETWORK [-s SCHEDULE] -p PROJECTION
                           [-np PROCESSES] -od OUTPUT_DIR

Simplify a MATSim network by removing intermediate links from paths

optional arguments:
  -h, --help            show this help message and exit
  -n NETWORK, --network NETWORK
                        Location of the network.xml file
  -s SCHEDULE, --schedule SCHEDULE
                        Location of the schedule.xml file
  -p PROJECTION, --projection PROJECTION
                        The projection network is in, eg. "epsg:27700"
  -np PROCESSES, --processes PROCESSES
                        The number of processes to split computation across
  -od OUTPUT_DIR, --output_dir OUTPUT_DIR
                        Output directory for the simplified network
```