### PR TITLE
Lab 1046 ValueError: cannot set a frame with no defined index and a scalar

### DIFF
--- a/genet/outputs_handler/geojson.py
+++ b/genet/outputs_handler/geojson.py
@@ -64,7 +64,7 @@ def save_network_to_geojson(n, output_dir):
 
 
 def generate_standard_outputs_for_schedule(schedule, output_dir, gtfs_day='19700101'):
-    logging.info('Generating geojson outputs for schedule')
+    logging.info('Generating geojson standard outputs for schedule')
     schedule_nodes, schedule_links = generate_geodataframes(schedule.graph())
     df = schedule.generate_trips_dataframe(gtfs_day=gtfs_day)
     df_all_modes_vph = None

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -382,7 +382,7 @@ class Route(ScheduleElement):
             route_nodes = [(stop, {}) for stop in stops]
             stop_edges = [(from_stop, to_stop) for from_stop, to_stop in zip(stops[:-1], stops[1:])]
         route_graph.add_nodes_from(route_nodes, routes=[self.id])
-        route_graph.add_edges_from(stop_edges, routes=[self.id], modes=[self.mode])
+        route_graph.add_edges_from(stop_edges, routes=[self.id])
         route_graph.graph['routes'] = {self.id: self._surrender_to_graph()}
         route_graph.graph['services'] = {}
         route_graph.graph['change_log'] = change_log.ChangeLog()

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Union, Dict, List
 from pyproj import Transformer
 import networkx as nx
@@ -71,9 +72,11 @@ class ScheduleElement:
     def change_log(self):
         return self._graph.graph['change_log']
 
+    @abstractmethod
     def reference_nodes(self):
         pass
 
+    @abstractmethod
     def reference_edges(self):
         pass
 
@@ -89,18 +92,18 @@ class ScheduleElement:
         for s in self.reference_nodes():
             yield self.stop(s)
 
+    @abstractmethod
+    def routes(self):
+        pass
+
+    @abstractmethod
     def modes(self):
-        edge_modes = self.graph().edges(data='modes')
-        modes = set()
-        for u, v, e_modes in edge_modes:
-            modes |= set(e_modes)
-        return list(modes)
+        pass
 
     def mode_graph_map(self):
         mode_map = {mode: set() for mode in self.modes()}
-        reference_edges = self.reference_edges()
-        for mode in mode_map:
-            mode_map[mode] = {(u, v) for u, v in reference_edges if mode in self._graph[u][v]['modes']}
+        for route in self.routes():
+            mode_map[route.mode] = mode_map[route.mode] | {(u, v) for u, v in route.reference_edges()}
         return mode_map
 
     def graph(self):
@@ -402,7 +405,7 @@ class Route(ScheduleElement):
         return {(u, v) for u, v, edge_routes in self._graph.edges(data='routes') if self.id in edge_routes}
 
     def modes(self):
-        return [self.mode]
+        return {self.mode}
 
     def _index_unique(self, idx):
         return idx not in self._graph.graph['routes']
@@ -734,6 +737,9 @@ class Service(ScheduleElement):
     def reference_edges(self):
         return {(u, v) for u, v, edge_services in self._graph.edges(data='services') if self.id in edge_services}
 
+    def modes(self):
+        return {r.mode for r in self.routes()}
+
     def _index_unique(self, idx):
         return idx not in self._graph.graph['services']
 
@@ -977,6 +983,22 @@ class Schedule(ScheduleElement):
 
     def reference_edges(self):
         return set(self._graph.edges())
+
+    def modes(self):
+        return set(self.route_attribute_data(keys='mode')['mode'].unique())
+
+    def mode_to_routes_map(self):
+        df = self.route_attribute_data(keys=['mode'], index_name='route_id').reset_index()
+        return df.groupby('mode')['route_id'].apply(list).to_dict()
+
+    def mode_graph_map(self):
+        mode_map = {}
+        mode_to_routes_map = self.mode_to_routes_map()
+        for mode, route_ids in mode_to_routes_map.items():
+            mode_map[mode] = set(graph_operations.extract_on_attributes(
+                iterator=[((u, v), data) for u, v, data in self._graph.edges(data=True)],
+                conditions={'routes': route_ids}))
+        return mode_map
 
     def reindex(self, new_id):
         if isinstance(self, Schedule):

--- a/tests/test_core_components_route.py
+++ b/tests/test_core_components_route.py
@@ -62,9 +62,9 @@ def test_initiating_route(route):
         '4': {'routes': ['1'], 'id': '4', 'x': 7.0, 'y': 5.0, 'epsg': 'epsg:27700', 'name': '',
               'lat': 49.766856648946295, 'lon': -7.5570681956375, 's2_id': 5205973754097123809,
               'additional_attributes': {'linkRefId'}, 'linkRefId': '4'}})
-    assert_semantically_equal(list(r._graph.edges(data=True)), [('1', '2', {'routes': ['1'], 'modes': ['bus']}),
-                                                                ('2', '3', {'routes': ['1'], 'modes': ['bus']}),
-                                                                ('3', '4', {'routes': ['1'], 'modes': ['bus']})])
+    assert_semantically_equal(list(r._graph.edges(data=True)), [('1', '2', {'routes': ['1']}),
+                                                                ('2', '3', {'routes': ['1']}),
+                                                                ('3', '4', {'routes': ['1']})])
     log = r._graph.graph.pop('change_log')
     assert log.empty
     assert_semantically_equal(r._graph.graph, {'name': 'Route graph', 'routes': {
@@ -126,9 +126,9 @@ def test_build_graph_builds_correct_graph():
                                      'lat': 49.766856648946295, 'lon': -7.5570681956375, 's2_id': 5205973754097123809,
                                      'name': '', 'additional_attributes': set()}})
     assert_semantically_equal(list(g.edges(data=True)),
-                              [('1', '2', {'routes': [''], 'modes': ['bus']}),
-                               ('2', '3', {'routes': [''], 'modes': ['bus']}),
-                               ('3', '4', {'routes': [''], 'modes': ['bus']})])
+                              [('1', '2', {'routes': ['']}),
+                               ('2', '3', {'routes': ['']}),
+                               ('3', '4', {'routes': ['']})])
 
 
 def test_routes_equal(stop_epsg_27700):

--- a/tests/test_core_components_service.py
+++ b/tests/test_core_components_service.py
@@ -80,12 +80,12 @@ def test_initiating_service(service):
               'lat': 49.76683608549253, 'lon': -7.557121424907424, 's2_id': 5205973754090203369,
               'additional_attributes': {'linkRefId'}, 'linkRefId': '3'}})
     assert_semantically_equal(list(s._graph.edges(data=True)),
-                              [('5', '6', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('6', '7', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('7', '8', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('1', '2', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('2', '3', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('3', '4', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']})])
+                              [('5', '6', {'services': ['service'], 'routes': ['2']}),
+                               ('6', '7', {'services': ['service'], 'routes': ['2']}),
+                               ('7', '8', {'services': ['service'], 'routes': ['2']}),
+                               ('1', '2', {'services': ['service'], 'routes': ['1']}),
+                               ('2', '3', {'services': ['service'], 'routes': ['1']}),
+                               ('3', '4', {'services': ['service'], 'routes': ['1']})])
     log = s._graph.graph.pop('change_log')
     assert log.empty
     assert_semantically_equal(s._graph.graph,
@@ -216,12 +216,12 @@ def test_build_graph_builds_correct_graph():
                                      'lat': 49.766856648946295, 'lon': -7.5570681956375, 's2_id': 5205973754097123809,
                                      'name': '', 'additional_attributes': set(), 'services': ['service']}})
     assert_semantically_equal(list(g.edges(data=True)),
-                              [('5', '6', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('6', '7', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('7', '8', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('1', '2', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('2', '3', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('3', '4', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']})])
+                              [('5', '6', {'services': ['service'], 'routes': ['2']}),
+                               ('6', '7', {'services': ['service'], 'routes': ['2']}),
+                               ('7', '8', {'services': ['service'], 'routes': ['2']}),
+                               ('1', '2', {'services': ['service'], 'routes': ['1']}),
+                               ('2', '3', {'services': ['service'], 'routes': ['1']}),
+                               ('3', '4', {'services': ['service'], 'routes': ['1']})])
 
 
 def test_build_graph_builds_correct_graph_when_some_stops_overlap():

--- a/tests/test_core_schedule.py
+++ b/tests/test_core_schedule.py
@@ -93,12 +93,12 @@ def test_initiating_schedule(schedule):
               'lat': 49.76683608549253, 'lon': -7.557121424907424, 's2_id': 5205973754090203369,
               'additional_attributes': set()}})
     assert_semantically_equal(list(s._graph.edges(data=True)),
-                              [('5', '6', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('6', '7', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('7', '8', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('1', '2', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('2', '3', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('3', '4', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']})])
+                              [('5', '6', {'services': ['service'], 'routes': ['2']}),
+                               ('6', '7', {'services': ['service'], 'routes': ['2']}),
+                               ('7', '8', {'services': ['service'], 'routes': ['2']}),
+                               ('1', '2', {'services': ['service'], 'routes': ['1']}),
+                               ('2', '3', {'services': ['service'], 'routes': ['1']}),
+                               ('3', '4', {'services': ['service'], 'routes': ['1']})])
     log = s._graph.graph.pop('change_log')
     assert log.empty
     assert_semantically_equal(s._graph.graph,
@@ -597,8 +597,8 @@ def test_adding_service_with_clashing_stops_data_does_not_overwrite_existing_sto
     schedule.add_service(s, force=True)
 
     assert_semantically_equal(dict(s.graph().nodes(data=True)), expected_stops_data)
-    assert_semantically_equal(s.graph()['1']['2'], {'routes': ['1', '3'], 'modes': ['bus'], 'services': ['some_id', 'service']})
-    assert_semantically_equal(s.graph()['2']['5'], {'routes': ['3'], 'modes': ['bus'], 'services': ['some_id']})
+    assert_semantically_equal(s.graph()['1']['2'], {'routes': ['1', '3'], 'services': ['some_id', 'service']})
+    assert_semantically_equal(s.graph()['2']['5'], {'routes': ['3'], 'services': ['some_id']})
 
 
 def test_adding_service_with_clashing_stops_data_without_force_flag_throws_error(schedule):
@@ -684,14 +684,14 @@ def test_creating_a_route_to_add_using_id_references_to_existing_stops_inherits_
     assert_semantically_equal(dict(r._graph.nodes(data=True)),
                               {'1': {'routes': ['3']}, '2': {'routes': ['3']}, '5': {'routes': ['3']}})
     assert_semantically_equal(list(r._graph.edges(data=True)),
-                              [('1', '2', {'routes': ['3'], 'modes': ['bus']}),
-                               ('2', '5', {'routes': ['3'], 'modes': ['bus']})])
+                              [('1', '2', {'routes': ['3']}),
+                               ('2', '5', {'routes': ['3']})])
 
     schedule.add_route('service', r)
 
     assert_semantically_equal(dict(r.graph().nodes(data=True)), expected_stops_data)
-    assert_semantically_equal(r.graph()['1']['2'], {'routes': ['1', '3'], 'modes': ['bus'], 'services': ['service']})
-    assert_semantically_equal(r.graph()['2']['5'], {'routes': ['3'], 'modes': ['bus'], 'services': ['service']})
+    assert_semantically_equal(r.graph()['1']['2'], {'routes': ['1', '3'], 'services': ['service']})
+    assert_semantically_equal(r.graph()['2']['5'], {'routes': ['3'], 'services': ['service']})
 
 
 def test_creating_a_route_to_add_giving_existing_schedule_stops(schedule):
@@ -730,14 +730,14 @@ def test_creating_a_route_to_add_giving_existing_schedule_stops(schedule):
                                      'lat': 49.76682779861249, 'lon': -7.557106577683727, 's2_id': 5205973754090531959,
                                      'additional_attributes': set()}})
     assert_semantically_equal(list(r._graph.edges(data=True)),
-                              [('1', '2', {'routes': ['3'], 'modes': ['bus']}),
-                               ('2', '5', {'routes': ['3'], 'modes': ['bus']})])
+                              [('1', '2', {'routes': ['3']}),
+                               ('2', '5', {'routes': ['3']})])
 
     schedule.add_route('service', r)
 
     assert_semantically_equal(dict(r.graph().nodes(data=True)), expected_stops_data)
-    assert_semantically_equal(r.graph()['1']['2'], {'routes': ['1', '3'], 'modes': ['bus'], 'services': ['service']})
-    assert_semantically_equal(r.graph()['2']['5'], {'routes': ['3'], 'modes': ['bus'], 'services': ['service']})
+    assert_semantically_equal(r.graph()['1']['2'], {'routes': ['1', '3'], 'services': ['service']})
+    assert_semantically_equal(r.graph()['2']['5'], {'routes': ['3'], 'services': ['service']})
 
 
 def test_adding_route_with_clashing_stops_data_does_not_overwrite_existing_stops(schedule):
@@ -771,8 +771,8 @@ def test_adding_route_with_clashing_stops_data_does_not_overwrite_existing_stops
     schedule.add_route('service', r, force=True)
 
     assert_semantically_equal(dict(r.graph().nodes(data=True)), expected_stops_data)
-    assert_semantically_equal(r.graph()['1']['2'], {'routes': ['1', '3'], 'modes': ['bus'], 'services': ['service']})
-    assert_semantically_equal(r.graph()['2']['5'], {'routes': ['3'], 'modes': ['bus'], 'services': ['service']})
+    assert_semantically_equal(r.graph()['1']['2'], {'routes': ['1', '3'], 'services': ['service']})
+    assert_semantically_equal(r.graph()['2']['5'], {'routes': ['3'], 'services': ['service']})
 
 
 def test_adding_route_with_clashing_stops_data_only_flags_those_that_are_actually_different(schedule):
@@ -869,12 +869,12 @@ def test_removing_route_updates_services_on_nodes_and_edges(schedule):
                                      'lon': -7.5570681956375, 's2_id': 5205973754097123809,
                                      'additional_attributes': set()}})
     assert_semantically_equal(list(schedule.graph().edges(data=True)),
-                              [('5', '6', {'services': [], 'routes': [], 'modes': ['bus']}),
-                               ('6', '7', {'services': [], 'routes': [], 'modes': ['bus']}),
-                               ('7', '8', {'services': [], 'routes': [], 'modes': ['bus']}),
-                               ('3', '4', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('1', '2', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('2', '3', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']})])
+                              [('5', '6', {'services': [], 'routes': []}),
+                               ('6', '7', {'services': [], 'routes': []}),
+                               ('7', '8', {'services': [], 'routes': []}),
+                               ('3', '4', {'services': ['service'], 'routes': ['1']}),
+                               ('1', '2', {'services': ['service'], 'routes': ['1']}),
+                               ('2', '3', {'services': ['service'], 'routes': ['1']})])
 
 
 def test_removing_stop(schedule):
@@ -1044,14 +1044,14 @@ def test_build_graph_builds_correct_graph(strongly_connected_schedule):
                                      'epsg': 'epsg:27700', 'lat': 49.766856648946295, 'lon': -7.5570681956375,
                                      's2_id': 5205973754097123809, 'additional_attributes': set(), 'name': 'Stop_4'}})
     assert_semantically_equal(list(g.edges(data=True)),
-                              [('5', '2', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('2', '7', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('2', '3', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('7', '8', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('8', '5', {'services': ['service'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('3', '4', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('4', '1', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']}),
-                               ('1', '2', {'services': ['service'], 'routes': ['1'], 'modes': ['bus']})])
+                              [('5', '2', {'services': ['service'], 'routes': ['2']}),
+                               ('2', '7', {'services': ['service'], 'routes': ['2']}),
+                               ('2', '3', {'services': ['service'], 'routes': ['1']}),
+                               ('7', '8', {'services': ['service'], 'routes': ['2']}),
+                               ('8', '5', {'services': ['service'], 'routes': ['2']}),
+                               ('3', '4', {'services': ['service'], 'routes': ['1']}),
+                               ('4', '1', {'services': ['service'], 'routes': ['1']}),
+                               ('1', '2', {'services': ['service'], 'routes': ['1']})])
 
 
 def test_building_trips_dataframe(schedule):

--- a/tests/test_core_schedule.py
+++ b/tests/test_core_schedule.py
@@ -458,6 +458,23 @@ def test_applying_attributes_to_route(schedule):
     assert schedule.route('1').route_short_name == 'new_name'
 
 
+def test_applying_mode_attributes_to_route_results_in_correct_mode_methods(schedule):
+    assert schedule.route('1').mode == 'bus'
+    assert schedule.modes() == {'bus'}
+    assert schedule.mode_graph_map() == {
+        'bus': {('3', '4'), ('2', '3'), ('1', '2'), ('6', '7'), ('5', '6'), ('7', '8')}}
+
+    schedule.apply_attributes_to_routes({'1': {'mode': 'new_bus'}})
+
+    assert schedule.route('1').mode == 'new_bus'
+    assert schedule.modes() == {'bus', 'new_bus'}
+    assert schedule['service'].modes() == {'bus', 'new_bus'}
+    assert schedule.mode_graph_map() == {'bus': {('7', '8'), ('6', '7'), ('5', '6')},
+                                         'new_bus': {('3', '4'), ('1', '2'), ('2', '3')}}
+    assert schedule['service'].mode_graph_map() == {'bus': {('6', '7'), ('7', '8'), ('5', '6')},
+                                                    'new_bus': {('3', '4'), ('2', '3'), ('1', '2')}}
+
+
 def test_applying_attributes_changing_id_to_route_throws_error(schedule):
     assert '1' in schedule._graph.graph['routes']
     assert schedule._graph.graph['routes']['1']['id'] == '1'

--- a/tests/test_core_schedule_elements.py
+++ b/tests/test_core_schedule_elements.py
@@ -237,8 +237,8 @@ def test_schedule_subgraph(schedule):
     sub_g = schedule.subgraph({('1', '2'), ('0', '1')})
 
     assert_semantically_equal(list(sub_g.edges(data=True)),
-                              [('1', '2', {'services': ['service1'], 'routes': ['2'], 'modes': ['bus']}),
-                               ('0', '1', {'services': ['service1'], 'routes': ['1'], 'modes': ['bus']})])
+                              [('1', '2', {'services': ['service1'], 'routes': ['2']}),
+                               ('0', '1', {'services': ['service1'], 'routes': ['1']})])
 
     assert_semantically_equal(dict(sub_g.nodes(data=True)),
                               {'0': {'services': ['service1'], 'routes': ['1'], 'id': '0', 'x': 529455.7452394223,
@@ -260,7 +260,7 @@ def test_service_subgraph(schedule):
     sub_g = schedule['service1'].subgraph({('0', '1')})
 
     assert_semantically_equal(list(sub_g.edges(data=True)),
-                              [('0', '1', {'services': ['service1'], 'routes': ['1'], 'modes': ['bus']})])
+                              [('0', '1', {'services': ['service1'], 'routes': ['1']})])
 
     assert_semantically_equal(dict(sub_g.nodes(data=True)),
                               {'0': {'services': ['service1'], 'routes': ['1'], 'id': '0', 'x': 529455.7452394223,
@@ -278,7 +278,7 @@ def test_route_subgraph(schedule):
     sub_g = schedule.route('1').subgraph({('0', '1')})
 
     assert_semantically_equal(list(sub_g.edges(data=True)),
-                              [('0', '1', {'services': ['service1'], 'routes': ['1'], 'modes': ['bus']})])
+                              [('0', '1', {'services': ['service1'], 'routes': ['1']})])
 
     assert_semantically_equal(dict(sub_g.nodes(data=True)),
                               {'1': {'services': ['service1'], 'routes': ['2', '1'], 'id': '1', 'x': 529350.7866124967,

--- a/tests/test_outputs_handler_geojson.py
+++ b/tests/test_outputs_handler_geojson.py
@@ -73,7 +73,6 @@ def test_generating_schedule_graph_geodataframe(network):
                      }
     correct_links = {'services': {0: ['service']},
                      'routes': {0: ['1', '2']},
-                     'modes': {0: ['bus']},
                      'u': {0: '0'},
                      'v': {0: '1'},
                      'key': {0: 0}}

--- a/tests/test_outputs_handler_geojson.py
+++ b/tests/test_outputs_handler_geojson.py
@@ -104,6 +104,11 @@ def test_modal_subset(network):
     assert car.loc[0, 'modes'] == ['car', 'walk']
 
 
+def test_generating_standard_outputs_after_modifying_modes_in_schedule(network, tmpdir):
+    network.schedule.apply_attributes_to_routes({'1': {'mode': 'different_bus'}, '2': {'mode': 'other_bus'}})
+    gngeojson.generate_standard_outputs_for_schedule(network.schedule, tmpdir)
+
+
 def test_save_to_geojson(network, tmpdir):
     assert os.listdir(tmpdir) == []
     network.save_network_to_geojson(tmpdir)


### PR DESCRIPTION
Fixes #61 
A couple of mode-related methods relied on modes data stored on the graph, which was not updated after the modes were changed. Modes are no longer saved on the graph and the methods use the Routes data directly. Relevant test before and after:
<img width="1132" alt="Screenshot 2021-03-01 at 20 56 57" src="https://user-images.githubusercontent.com/36536946/109625158-e4158c80-7b36-11eb-8dd7-78ff4cf8362f.png">
<img width="1429" alt="Screenshot 2021-03-01 at 20 57 33" src="https://user-images.githubusercontent.com/36536946/109625172-e7a91380-7b36-11eb-84e1-51f420cb2b7b.png">
