### PR TITLE
Mf lab 1051 notebook smoketests

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -36,6 +36,9 @@ jobs:
       run: |
         export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
         ./bash_scripts/code-coverage.sh
+    - name: Smoke test notebooks
+      run: |
+        ./bash_scripts/notebooks-smoke-test.sh
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -31,7 +31,7 @@ jobs:
         pip install -e .
     - name: Lint with flake8
       run: |
-        flake8 . --max-line-length 120 --count  --show-source --statistics --exclude=scripts,tests
+        flake8 . --max-line-length 120 --count  --show-source --statistics --exclude=scripts,tests,notebooks
     - name: Unit tests
       run: |
         export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ mprofile*
 benchmark-outputs/
 working-dir/
 scripts/secrets-mgr-exploration.py
+*.nbconvert.*

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ benchmark-outputs/
 working-dir/
 scripts/secrets-mgr-exploration.py
 *.nbconvert.*
+example_data/pt2matsim_network/genet_output/*
+genet_output/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,22 +53,24 @@ issue.
 [`bash_scripts/code-coverage.sh`](https://github.com/arup-group/genet/blob/master/bash_scripts/code-coverage.sh)
  will help both in checking that the coverage level is satisfied and investigating places in code that have not been 
  covered by the tests (via an output file `reports/coverage/index.html` which can be viewed in a browser).
-3. Provide [docstrings](https://www.python.org/dev/peps/pep-0257/) for new methods 
-4. Perform linting locally using ```flake8 . --max-line-length 120 --count  --show-source --statistics --exclude=scripts,tests```
-5. Add or update dependencies in `requirements.txt` if applicable
-6. Ensure the CI build pipeline (Actions tab in GitHub) completes successfully for your branch. The pipeline performs 
+3. Ensure the sample notebooks execute without error by running `./bash_scripts/notebooks-smoke-test.sh`. Problems in
+the core GeNet APIs or in the notebooks themselves can both cause notebook failures.
+4. Provide [docstrings](https://www.python.org/dev/peps/pep-0257/) for new methods
+5. Perform linting locally using ```flake8 . --max-line-length 120 --count  --show-source --statistics --exclude=scripts,tests```
+6. Add or update dependencies in `requirements.txt` if applicable
+7. Ensure the CI build pipeline (Actions tab in GitHub) completes successfully for your branch. The pipeline performs
 automated `PEP8` checks and runs unit tests in a fresh environment, as well as installation of all dependencies.
-7. Update/add to or generate a new jupyter notebook in `notebooks` directory which takes the user through your new feature or
+8. Update/add to or generate a new jupyter notebook in `notebooks` directory which takes the user through your new feature or
 change. You may use example data already in `example_data` directory of this repo, or add more (small amount of) data to
 it to show off your new features.
-8. Add section in the `README.md` which shows usage of your new feature. This can be paraphrased from the jupyter
+9. Add section in the `README.md` which shows usage of your new feature. This can be paraphrased from the jupyter
 notebook in point above.
-9. If the feature is to be used in an automated workflow through the docker image, create n example script in the 
+10. If the feature is to be used in an automated workflow through the docker image, create n example script in the 
 `scripts` directory. Please use existing scripts as templates.
-10. Submit your Pull Request (see [GitHub Docs on Creating a Pull Request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)),
+11. Submit your Pull Request (see [GitHub Docs on Creating a Pull Request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)),
  describing the feature, linking to any relevant GitHub issues and request review from at 
 least two developers. (Please take a look at latest commits to find out which developers you should request review from)
-11. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
+12. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
 do not have permission to do that, please request one of the reviewers to merge it for you.
 
 ## Attribution

--- a/bash_scripts/notebooks-smoke-test.sh
+++ b/bash_scripts/notebooks-smoke-test.sh
@@ -1,50 +1,9 @@
 #!/usr/bin/env bash
 
-# text colours
-PLAIN='\033[0m'
-EM='\033[0;93m'
-QUOTE='\033[0;34m'
-SUCCESS='\033[0;32m'
-FAILURE='\033[0;31m'
-
-CHECKMARK_SYMBOL='\xE2\x9C\x94'
-CROSS_SYMBOL='\xE2\x9D\x8C'
-
-function print-result-symbol() {
-  exit_code=$1
-  if test $exit_code -eq 0
-  then
-    printf "${SUCCESS}${CHECKMARK_SYMBOL}${PLAIN}"
-  else
-    printf "${FAILURE}${CROSS_SYMBOL}${PLAIN}"
-  fi
-}
+set -e
 
 pushd "${0%/*}"/..
 
-printf "Installing a Jupyter kernel for genet...\n"
-ipython kernel install --name "genet" --user
-printf "Looking for notebooks...\n"
+python notebooks/notebook_smoke_tests.py -d notebooks -k genet
 
-find notebooks -type f -name '*.ipynb' -maxdepth 1 -print0 | sort |
-while IFS= read -r -d '' file; do
-    printf "\nFound '$file'"
-done
-echo ""
-
-nb_count=0
-find notebooks -type f -name '*.ipynb' -maxdepth 1 -print0 | sort |
-{
-    while IFS= read -r -d '' file; do
-        printf "${PLAIN}-----------------------------------------------------------\n"
-        nb_count=$(expr $nb_count + 1)
-        printf "Notebook ${EM}$nb_count${PLAIN}"
-        printf "\nExecuting ${EM}$file${QUOTE}\n"
-        jupyter nbconvert --to notebook --execute "$file" --output-dir=/tmp
-        exit_code=$?
-        printf "${EM}$file${PLAIN} exit code was ${EM}$exit_code${PLAIN}\n"
-    done
-
-    printf "\n\nExecuted ${EM}$nb_count${PLAIN} notebooks - finished the smoke test\n"
-}
 popd

--- a/bash_scripts/notebooks-smoke-test.sh
+++ b/bash_scripts/notebooks-smoke-test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# text colours
+PLAIN='\033[0m'
+EM='\033[0;93m'
+QUOTE='\033[0;34m'
+SUCCESS='\033[0;32m'
+FAILURE='\033[0;31m'
+
+CHECKMARK_SYMBOL='\xE2\x9C\x94'
+CROSS_SYMBOL='\xE2\x9D\x8C'
+
+function print-result-symbol() {
+  exit_code=$1
+  if test $exit_code -eq 0
+  then
+    printf "${SUCCESS}${CHECKMARK_SYMBOL}${PLAIN}"
+  else
+    printf "${FAILURE}${CROSS_SYMBOL}${PLAIN}"
+  fi
+}
+
+pushd "${0%/*}"/..
+
+printf "Installing a Jupyter kernel for genet...\n"
+ipython kernel install --name "genet" --user
+printf "Looking for notebooks...\n"
+
+find notebooks -type f -name '*.ipynb' -maxdepth 1 -print0 | sort |
+while IFS= read -r -d '' file; do
+    printf "\nFound '$file'"
+done
+echo ""
+
+nb_count=0
+find notebooks -type f -name '*.ipynb' -maxdepth 1 -print0 | sort |
+{
+    while IFS= read -r -d '' file; do
+        printf "${PLAIN}-----------------------------------------------------------\n"
+        nb_count=$(expr $nb_count + 1)
+        printf "Notebook ${EM}$nb_count${PLAIN}"
+        printf "\nExecuting ${EM}$file${QUOTE}\n"
+        jupyter nbconvert --to notebook --execute "$file" --output-dir=/tmp
+        exit_code=$?
+        printf "${EM}$file${PLAIN} exit code was ${EM}$exit_code${PLAIN}\n"
+    done
+
+    printf "\n\nExecuted ${EM}$nb_count${PLAIN} notebooks - finished the smoke test\n"
+}
+popd

--- a/notebooks/1. Intro.ipynb
+++ b/notebooks/1. Intro.ipynb
@@ -707,7 +707,7 @@
     }
    ],
    "source": [
-    "n.change_log.log.head(10)"
+    "n.change_log.head(10)"
    ]
   },
   {

--- a/notebooks/5.1. Modifying Network - Basics.ipynb
+++ b/notebooks/5.1. Modifying Network - Basics.ipynb
@@ -1617,7 +1617,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for route_id in {'another_new_route', 'another_new_route'}:\n",
+    "for route_id in {'another_new_route', 'another_new_route_2', 'another_new_route_3'}:\n",
     "    n.schedule.remove_route(route_id)"
    ]
   },

--- a/notebooks/6.2. Validating Network - Google Directions API.ipynb
+++ b/notebooks/6.2. Validating Network - Google Directions API.ipynb
@@ -141,7 +141,7 @@
    },
    "outputs": [],
    "source": [
-    "api_requests = google_directions.read_saved_api_results('../example_data/example_google_speed_data')"
+    "api_requests = google_directions.read_saved_api_results('../example_data/example_google_speed_data/api_requests.json')"
    ]
   },
   {

--- a/notebooks/notebook_smoke_tests.py
+++ b/notebooks/notebook_smoke_tests.py
@@ -25,6 +25,31 @@ def parse_args(cmd_args):
     return vars(arg_parser.parse_args(cmd_args))
 
 
+def print_banner():
+    banner = '''
+ a,  8a
+ `8, `8)                            ,adPPRg,
+  8)  ]8                        ,ad888888888b
+ ,8' ,8'                    ,gPPR888888888888
+,8' ,8'                 ,ad8""   `Y888888888P
+8)  8)              ,ad8""        (8888888""
+8,  8,          ,ad8""            d888""
+`8, `8,     ,ad8""            ,ad8""
+ `8, `" ,ad8""            ,ad8""
+    ,gPPR8b           ,ad8""
+   dP:::::Yb      ,ad8""
+   8):::::(8  ,ad8""
+   Yb:;;;:d888""
+    "8ggg8P"
+ _   _ ____    ____  __  __  ___  _  _______   _____ _____ ____ _____
+| \ | | __ )  / ___||  \/  |/ _ \| |/ / ____| |_   _| ____/ ___|_   _|
+|  \| |  _ \  \___ \| |\/| | | | | ' /|  _|     | | |  _| \___ \ | |
+| |\  | |_) |  ___) | |  | | |_| | . \| |___    | | | |___ ___) || |
+|_| \_|____/  |____/|_|  |_|\___/|_|\_\_____|   |_| |_____|____/ |_|
+    '''
+    print("{}{}{}".format(Fore.CYAN, banner, Style.RESET_ALL))
+
+
 def install_jupyter_kernel(kernel_name):
     print("Making sure we have a Jupyter kernel called {}{}{} installed...".format(Fore.YELLOW,
                                                                                    kernel_name,
@@ -72,6 +97,7 @@ def print_summary(notebook_results_dict):
 
 
 if __name__ == '__main__':
+    print_banner()
     start = datetime.now()
     command_args = parse_args(sys.argv[1:])
     print("Smoke testing Jupyter notebooks in {}'{}'{} directory".format(Fore.YELLOW,
@@ -104,3 +130,4 @@ if __name__ == '__main__':
     print('------------------------------------------------------')
     print("\nFinished the smoke test in {}{}{}".format(Fore.YELLOW, datetime.now() - start, Style.RESET_ALL))
     print_summary(notebook_results)
+    sys.exit(sum(notebook_results.values()))

--- a/notebooks/notebook_smoke_tests.py
+++ b/notebooks/notebook_smoke_tests.py
@@ -1,0 +1,106 @@
+import argparse
+import glob
+import subprocess
+import sys
+
+from datetime import datetime
+from pprint import pprint
+
+from colorama import Fore, Style
+
+TICK_SYMBOL = u'\u2713'
+CROSS_SYMBOL = u'\u274C'
+
+
+def parse_args(cmd_args):
+    arg_parser = argparse.ArgumentParser(description='Smoke test a set of Jupyter notebook files')
+    arg_parser.add_argument('-d',
+                            '--notebook-directory',
+                            help='the path to the directory containing the notebooks to test',
+                            required=True)
+    arg_parser.add_argument('-k',
+                            '--kernel-name',
+                            help='the name of the Jupyter kernel to install',
+                            required=True)
+    return vars(arg_parser.parse_args(cmd_args))
+
+
+def install_jupyter_kernel(kernel_name):
+    print("Making sure we have a Jupyter kernel called {}{}{} installed...".format(Fore.YELLOW,
+                                                                                   kernel_name,
+                                                                                   Style.RESET_ALL))
+    kernel_install_cmd = [
+        'ipython', 'kernel', 'install',
+        '--name', '"{}"'.format(kernel_name),
+        '--user'
+    ]
+    return run_shell_command(kernel_install_cmd)
+
+
+def execute_notebook(notebook_path):
+    print("Executing notebook '{}{}{}'...".format(Fore.YELLOW, notebook_path, Style.RESET_ALL))
+    kernel_install_cmd = [
+        'jupyter', 'nbconvert',
+        '--to', 'notebook',
+        '--execute', '"{}"'.format(notebook_path),
+        '--output-dir=/tmp'
+    ]
+    return run_shell_command(kernel_install_cmd)
+
+
+def run_shell_command(shell_cmd):
+    print(Fore.BLUE + ' '.join(shell_cmd))
+    rc = subprocess.call(' '.join(shell_cmd), shell=True)
+    print("{}Shell process return value was {}{}{}".format(Style.RESET_ALL, Fore.YELLOW, rc, Style.RESET_ALL))
+    return rc, ' '.join(shell_cmd)
+
+
+def find_notebooks(notebook_dir):
+    notebook_paths = glob.glob("{}/*.ipynb".format(notebook_dir))
+    notebook_paths.sort()
+    return notebook_paths
+
+
+def print_summary(notebook_results_dict):
+    print("\n                     Summary")
+    print("-------------------------------------------------------------")
+    for notebook_file, result in notebook_results_dict.items():
+        short_name = notebook_file.split('/')[-1]
+        colour = Fore.GREEN if result == 0 else Fore.RED
+        result_symbol = TICK_SYMBOL if result == 0 else CROSS_SYMBOL
+        print("{}: {}{}{}".format(short_name, colour, result_symbol, Style.RESET_ALL))
+
+
+if __name__ == '__main__':
+    start = datetime.now()
+    command_args = parse_args(sys.argv[1:])
+    print("Smoke testing Jupyter notebooks in {}'{}'{} directory".format(Fore.YELLOW,
+                                                                         command_args['notebook_directory'],
+                                                                         Style.RESET_ALL))
+    notebooks = find_notebooks(command_args['notebook_directory'])
+    print("Found {}{}{} notebooks files in {}{}{}".format(Fore.YELLOW,
+                                                          len(notebooks),
+                                                          Style.RESET_ALL,
+                                                          Fore.YELLOW,
+                                                          command_args['notebook_directory'],
+                                                          Style.RESET_ALL))
+    if not notebooks:
+        print("No notebooks to test - our work here is done. Double check the {}{}{} directory if this seems wrong."
+              .format(Fore.YELLOW, command_args['notebook_directory'], Style.RESET_ALL))
+        sys.exit(0)
+
+    pprint(notebooks, width=120)
+    return_code, cmd = install_jupyter_kernel(command_args['kernel_name'])
+    if return_code:
+        print("{}Warning: Jupyter kernel installation shell command did not exit normally"
+              " - this may cause problems later{}".format(Fore.RED, Style.RESET_ALL))
+
+    notebook_results = {}
+    for notebook in notebooks:
+        print('------------------------------------------------------')
+        return_code, cmd = execute_notebook(notebook)
+        notebook_results[notebook] = return_code
+
+    print('------------------------------------------------------')
+    print("\nFinished the smoke test in {}{}{}".format(Fore.YELLOW, datetime.now() - start, Style.RESET_ALL))
+    print_summary(notebook_results)

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ matplotlib==3.2.1
 memory-profiler==0.57.0
 more-itertools==8.3.0
 munch==2.5.0
+nbconvert==6.0.7
 networkx==2.4
 nose==1.3.7
 numpy==1.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ ipython==7.14.0
 ipython-genutils==0.2.0
 jedi==0.17.0
 jmespath==0.10.0
-jupyter-client==6.1.3
+jupyter-client==6.1.5
 jupyter-core==4.6.3
 kiwisolver==1.2.0
 lxml==4.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ botocore==1.17.16
 certifi==2020.4.5.2
 chardet==3.0.4
 cligj==0.5.0
+colorama==0.4.4
 coverage==5.1
 cycler==0.10.0
 decorator==4.4.2


### PR DESCRIPTION
See https://arupdigital.atlassian.net/browse/LAB-1051

Adds a python script to discover and execute all notebooks. 

I wrote this in Python rather than pure bash because of bash 3's lack of support for dictionaries/maps/associative arrays and other such limitations, but I am still invoking `nbconvert` as a bash command, rather than using the `nbconvert` [Python API](https://nbconvert.readthedocs.io/en/latest/execute_api.html#executing-notebooks-using-the-python-api-interface). This is because Andrew Kay mentioned that the Python API is not supported on Windows.

I have added this smoke test to the CI build, which was already quite slow, and is now c. 2 minutes slower, but I think it's worth it.

The smoke test identified 3 notebooks with minor errors, all of which are fixed in this PR:

<img width="1350" alt="genet-ci-build-failing-nb-smoketests" src="https://user-images.githubusercontent.com/250899/110833788-b944da00-8294-11eb-81c9-576822903185.png">

<img width="1373" alt="genet-ci-build-nb-smoktest-2" src="https://user-images.githubusercontent.com/250899/110833841-c5309c00-8294-11eb-840a-fd6c37fdcb3e.png">



 