### PR TITLE
add missing always_xy=True to a couple of transformers

### DIFF
--- a/genet/inputs_handler/matsim_reader.py
+++ b/genet/inputs_handler/matsim_reader.py
@@ -182,7 +182,7 @@ def read_schedule(schedule_path, epsg):
     :return: list of Service objects
     """
     services = []
-    transformer = Transformer.from_proj(Proj(epsg), Proj('epsg:4326'))
+    transformer = Transformer.from_proj(Proj(epsg), Proj('epsg:4326'), always_xy=True)
 
     def write_transitLinesTransitRoute(transitLine, transitRoutes, transportMode):
         mode = transportMode['transportMode']

--- a/genet/outputs_handler/matsim_xml_writer.py
+++ b/genet/outputs_handler/matsim_xml_writer.py
@@ -102,7 +102,7 @@ def write_matsim_schedule(output_dir, schedule, epsg=''):
     fname = os.path.join(output_dir, "schedule.xml")
     if not epsg:
         epsg = schedule.epsg
-    transformer = Transformer.from_proj(Proj('epsg:4326'), Proj(epsg))
+    transformer = Transformer.from_proj(Proj('epsg:4326'), Proj(epsg), always_xy=True)
     logging.info('Writing {}'.format(fname))
 
     with open(fname, "wb") as f, etree.xmlfile(f, encoding='utf-8') as xf:

--- a/tests/test_core_schedule.py
+++ b/tests/test_core_schedule.py
@@ -956,6 +956,20 @@ def test_read_matsim_schedule_returns_expected_schedule():
     assert_semantically_equal(schedule.route('VJbd8660f05fe6f744e58a66ae12bd66acbca88b98').trips,
                               {'trip_id': ['VJ00938baa194cee94700312812d208fe79f3297ee_04:40:00'],
                                'trip_departure_time': ['04:40:00'], 'vehicle_id': ['veh_0_bus']})
+    assert_semantically_equal(
+        dict(schedule.graph().nodes(data=True)),
+        {'26997928P': {'services': {'10314'}, 'routes': {'VJbd8660f05fe6f744e58a66ae12bd66acbca88b98'},
+                       'id': '26997928P', 'x': 528464.1342843144, 'y': 182179.7435136598, 'epsg': 'epsg:27700',
+                       'name': 'Brunswick Place (Stop P)', 'lat': 51.52393050617373, 'lon': -0.14967658860132668,
+                       's2_id': 5221390302759871369, 'additional_attributes': {'name', 'isBlocking'},
+                       'isBlocking': 'false'},
+         '26997928P.link:1': {'services': {'10314'}, 'routes': {'VJbd8660f05fe6f744e58a66ae12bd66acbca88b98'},
+                              'id': '26997928P.link:1', 'x': 528464.1342843144, 'y': 182179.7435136598,
+                              'epsg': 'epsg:27700', 'name': 'Brunswick Place (Stop P)', 'lat': 51.52393050617373,
+                              'lon': -0.14967658860132668, 's2_id': 5221390302759871369,
+                              'additional_attributes': {'name', 'linkRefId', 'isBlocking'}, 'linkRefId': '1',
+                              'isBlocking': 'false'}}
+    )
 
 
 def test_reading_vehicles_with_a_schedule():


### PR DESCRIPTION
Reading MATSim schedule, a transformer did not contain `always_xy=True` attribute resulting in a lat lon swap.

![Screenshot 2021-04-27 at 10 22 28](https://user-images.githubusercontent.com/36536946/116221877-f29eaf80-a745-11eb-85ed-28b45160a375.png)
![Screenshot 2021-04-27 at 10 22 48](https://user-images.githubusercontent.com/36536946/116221884-f4687300-a745-11eb-9715-d4abacc542ee.png)
