### PR TITLE
Fix network simplification script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ scripts/secrets-mgr-exploration.py
 *.nbconvert.*
 example_data/pt2matsim_network/genet_output/*
 genet_output/*
+example_data/output_*/*

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -1,11 +1,11 @@
 import argparse
-import genet as gn
-import logging
-import time
-import os
 import json
-from genet.utils.persistence import ensure_dir
+import logging
+import os
+import time
 
+from genet import read_matsim
+from genet.utils.persistence import ensure_dir
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser(description='Simplify a MATSim network by removing '
@@ -56,16 +56,14 @@ if __name__ == '__main__':
 
     logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.WARNING)
 
-    n = gn.Network(projection)
     logging.info('Reading in network at {}'.format(network))
-    n.read_matsim_network(network)
-    if schedule:
-        logging.info(f'Reading in schedule at {schedule}')
-        if vehicles:
-            logging.info(f'Reading in vehicles at {vehicles}')
-        else:
-            logging.info('No vehicles file given with the Schedule, vehicle types will be based on the default.')
-        n.read_matsim_schedule(schedule, vehicles)
+    n = read_matsim(
+        path_to_network=network,
+        epsg=projection,
+        path_to_schedule=schedule,
+        path_to_vehicles=vehicles
+    )
+
     logging.info('Simplifying the Network.')
 
     start = time.time()


### PR DESCRIPTION
The network simplification tool had not been updated for the recent changes to GeNet's core network API. At the time I created this PR, I didn't think about the other scripts, but some of them will no doubt be suffering from the same problem - let's fix all of those in a different PR.

### Running a Matesto pipeline including a network simplification step before this change

<img width="1322" alt="Screen Shot 2021-04-28 at 03 29 51" src="https://user-images.githubusercontent.com/250899/116338142-3095e500-a7d3-11eb-8260-8b6d4aed803e.png">

<img width="1440" alt="Screen Shot 2021-04-28 at 03 30 15" src="https://user-images.githubusercontent.com/250899/116338046-0ba17200-a7d3-11eb-9c40-8b11791f41f0.png">

### Running a Matesto pipeline including a network simplification step after this change

<img width="1342" alt="Screen Shot 2021-04-28 at 03 24 22" src="https://user-images.githubusercontent.com/250899/116338196-4b685980-a7d3-11eb-9c4b-50cc3cf294a5.png">
<img width="1315" alt="Screen Shot 2021-04-28 at 03 25 48" src="https://user-images.githubusercontent.com/250899/116338338-79e63480-a7d3-11eb-8c8b-c3cb2c36b415.png">

