### PR TITLE
Add manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include genet/configs *


### PR DESCRIPTION
Adds a [manifest](https://packaging.python.org/guides/using-manifest-in/) so that genet's source distribution, as pulled in via scop's [requirements.txt](https://github.com/arup-group/scop/blob/finish-csv-read-write/requirements.txt), for example, includes the necessary genet config files from `genet/configs`.

In `scop`, after `pip install -r requirements.txt` but before adding the genet manifest:

<img width="1163" alt="Screen Shot 2021-08-06 at 16 36 14" src="https://user-images.githubusercontent.com/250899/128536209-860a5702-8eaa-408c-8f41-deccb7ef70aa.png">

After adding the manifest, the missing genet config files are now available after `pip install -r requirements.txt`:

<img width="1015" alt="Screen Shot 2021-08-06 at 16 35 20" src="https://user-images.githubusercontent.com/250899/128536442-e4d69053-0ea8-4eae-b124-202832301fcb.png">
<img width="1072" alt="Screen Shot 2021-08-06 at 16 35 34" src="https://user-images.githubusercontent.com/250899/128536398-c40ec53d-caa8-40fc-b131-9cc2e0094734.png">

You can now see the genet configs directory inside my scop venv:

```bash
$ tree /Users/mickyfitz/.pyenv/versions/scop-3.7.6/lib/python3.7/site-packages/genet/configs/
/Users/mickyfitz/.pyenv/versions/scop-3.7.6/lib/python3.7/site-packages/genet/configs/
├── OSM
│   ├── default_config.yml
│   └── slim_config.yml
└── vehicles
    └── vehicle_definitions.yml

2 directories, 3 files
```

