### PR TITLE
Update requirements

### DIFF
--- a/genet/core.py
+++ b/genet/core.py
@@ -505,7 +505,7 @@ class Network:
         if ('to' not in df_edges.columns) or (df_edges['to'].isnull().any()):
             raise RuntimeError('You are trying to add edges which are missing `to` (destination) nodes')
 
-        df_edges['id'] = self.generate_indices_for_n_edges(len(df_edges))
+        df_edges['id'] = list(self.generate_indices_for_n_edges(len(df_edges)))
         df_edges = df_edges.set_index('id', drop=False)
 
         return self.add_links(df_edges.T.to_dict(), silent=silent, ignore_change_log=ignore_change_log)
@@ -993,6 +993,7 @@ class Network:
         :param silent: whether to mute stdout logging messages
         :return:
         """
+        links = list(links)
         if not ignore_change_log:
             self.change_log = self.change_log.remove_bunch(
                 object_type='link', id_bunch=links, attributes_bunch=[self.link(link_id) for link_id in links])

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ jmespath==0.10.0
 jupyter-client==6.1.5
 jupyter-core==4.6.3
 kiwisolver==1.2.0
-lxml==4.6.2
+lxml>=4.6.2
 matplotlib==3.2.1
 memory-profiler==0.57.0
 more-itertools==8.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ descartes==1.1.0
 dictdiffer==0.8.1
 docutils==0.15.2
 Fiona==1.8.13.post1
-flake8==3.8.4
+flake8>=3.8.4
 future==0.18.2
 geopandas==0.9.0
 idna==2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,13 +54,13 @@ ptyprocess==0.6.0
 py>=1.8.1
 Pygments==2.7.4
 pyparsing==2.4.7
-pyproj==2.6.1.post1
-pytest==5.4.2
-pytest-cov==2.8.1
+pyproj==3.1.0
+pytest>=5.4.2
+pytest-cov>=2.8.1
 pytest-mock==3.1.0
 python-dateutil==2.8.1
 pytz==2020.1
-PyUtilib==5.8.0
+PyUtilib>=5.8.0
 PyYAML==5.4
 pyzmq==19.0.1
 requests==2.23.0
@@ -74,7 +74,7 @@ tabulate==0.8.7
 tornado==6.1
 tqdm==4.48.0
 traitlets==4.3.3
-urllib3==1.25.9
+urllib3>=1.25.1
 wcwidth==0.1.9
 xmltodict==0.12.0
 zipp==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ munch==2.5.0
 nbconvert==6.0.7
 networkx==2.4
 nose==1.3.7
-numpy==1.18.4
+numpy>=1.18.4
 osmnx==0.15.0
 osmread @ git+https://github.com/dezhin/osmread.git@d8d3fe5edd15fdab9526ea7a100ee6c796315663#egg=osmread-0.2.dev0
 packaging==20.4
@@ -53,7 +53,7 @@ ptyprocess==0.6.0
 py>=1.8.1
 Pygments==2.7.4
 pyparsing==2.4.7
-pyproj==3.1.0
+pyproj>=3.1.0
 pytest>=5.4.2
 pytest-cov>=2.8.1
 pytest-mock==3.1.0
@@ -62,7 +62,7 @@ pytz==2020.1
 PyUtilib>=5.8.0
 PyYAML==5.4
 pyzmq==19.0.1
-requests==2.23.0
+requests==2.26.0
 requests-futures==1.0.0
 Rtree==0.9.4
 s2sphere==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ decorator==4.4.2
 descartes==1.1.0
 dictdiffer==0.8.1
 docutils==0.15.2
-Fiona==1.8.13.post1
 flake8>=3.8.4
 future==0.18.2
 geopandas==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ certifi==2020.4.5.2
 chardet==3.0.4
 cligj==0.5.0
 colorama==0.4.4
-coverage==5.1
+coverage>=5.1
 cycler==0.10.0
 decorator==4.4.2
 descartes==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ munch==2.5.0
 nbconvert==6.0.7
 networkx==2.4
 nose==1.3.7
-numpy>=1.18.4
+numpy==1.18.4
 osmnx==0.15.0
 osmread @ git+https://github.com/dezhin/osmread.git@d8d3fe5edd15fdab9526ea7a100ee6c796315663#egg=osmread-0.2.dev0
 packaging==20.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ numpy>=1.18.4
 osmnx==0.15.0
 osmread @ git+https://github.com/dezhin/osmread.git@d8d3fe5edd15fdab9526ea7a100ee6c796315663#egg=osmread-0.2.dev0
 packaging==20.4
-pandas==1.0.3
+pandas>=1.0.3
 parso==0.7.0
 pexpect==4.8.0
 pickleshare==0.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ polyline==1.4.0
 prompt-toolkit==3.0.5
 protobuf==3.0.0b3
 ptyprocess==0.6.0
-py==1.8.1
+py>=1.8.1
 Pygments==2.7.4
 pyparsing==2.4.7
 pyproj==2.6.1.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ munch==2.5.0
 nbconvert==6.0.7
 networkx==2.4
 nose==1.3.7
-numpy==1.18.4
+numpy>=1.18.4
 osmnx==0.15.0
 osmread @ git+https://github.com/dezhin/osmread.git@d8d3fe5edd15fdab9526ea7a100ee6c796315663#egg=osmread-0.2.dev0
 packaging==20.4


### PR DESCRIPTION
Updates requirements to be compatible with MC, so that [scop](https://github.com/arup-group/scop) can install both:
Before:
<img width="1440" alt="Screenshot 2021-08-09 at 16 36 11" src="https://user-images.githubusercontent.com/36536946/128733410-24c2b18a-4c90-4f92-9d40-4a0b9a373dd4.png">
After:
<img width="1440" alt="Screenshot 2021-08-09 at 16 35 00" src="https://user-images.githubusercontent.com/36536946/128733431-1eac5888-836c-42ca-bee4-325ad1ffeda2.png">

Minimal changes to code - pandas was no longer happy with setting sets into columns and for a good (unordered) reason! Corrected that.