### PR TITLE
required python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,5 +75,6 @@ tqdm==4.48.0
 traitlets==4.3.3
 urllib3>=1.25.1
 wcwidth==0.1.9
+wheel==0.36.2
 xmltodict==0.12.0
 zipp==3.1.0


### PR DESCRIPTION
When I installed the genet in the workbox, it seems to require the `wheel` by showing the following error
` error: invalid command 'bdist_wheel'
` so I put it onto the requirement list which works for me. 