### PR TITLE
PT network route GeoDataFrame and geojson output

### DIFF
--- a/genet/core.py
+++ b/genet/core.py
@@ -1105,7 +1105,7 @@ class Network:
     def schedule_network_routes_geodataframe(self):
         if not self.schedule:
             logging.warning('Schedule in this Network is empty')
-            return gpd.GeoDataFrame()
+            return gpd.GeoDataFrame().set_crs(self.epsg)
 
         def combine_geometry(group):
             group = group.sort_values(by='route_sequence')
@@ -1131,7 +1131,7 @@ class Network:
         # get geometry for link IDs
         routes = pd.merge(routes, gdf_links[['id', 'geometry']], left_on='route', right_on='id')
         routes = routes.groupby('route_id').apply(combine_geometry).reset_index(drop=True)
-        return gpd.GeoDataFrame(routes)
+        return gpd.GeoDataFrame(routes).set_crs(self.epsg)
 
     def node_id_exists(self, node_id):
         if node_id in [i for i, attribs in self.nodes()]:

--- a/genet/outputs_handler/geojson.py
+++ b/genet/outputs_handler/geojson.py
@@ -206,3 +206,11 @@ def generate_standard_outputs(n, output_dir, gtfs_day='19700101', include_shp_fi
             gtfs_day=gtfs_day,
             include_shp_files=include_shp_files
         )
+
+        logging.info('Generating PT network routes')
+        save_geodataframe(
+            n.schedule_network_routes_geodataframe(),
+            filename='schedule_network_routes_geodataframe',
+            output_dir=os.path.join(output_dir, 'routing'),
+            include_shp_files=include_shp_files
+        )

--- a/genet/outputs_handler/geojson.py
+++ b/genet/outputs_handler/geojson.py
@@ -209,7 +209,7 @@ def generate_standard_outputs(n, output_dir, gtfs_day='19700101', include_shp_fi
 
         logging.info('Generating PT network routes')
         save_geodataframe(
-            n.schedule_network_routes_geodataframe(),
+            n.schedule_network_routes_geodataframe().to_crs('epsg:4326'),
             filename='schedule_network_routes_geodataframe',
             output_dir=os.path.join(output_dir, 'routing'),
             include_shp_files=include_shp_files

--- a/genet/utils/spatial.py
+++ b/genet/utils/spatial.py
@@ -4,7 +4,8 @@ import networkx as nx
 import numpy as np
 import statistics
 import json
-from shapely.geometry import LineString, shape, GeometryCollection
+from shapely.geometry import LineString, shape, GeometryCollection, MultiLineString
+from shapely.ops import linemerge
 import pandas as pd
 import geopandas as gpd
 import genet.outputs_handler.geojson as gngeojson
@@ -37,6 +38,16 @@ def swap_x_y_in_linestring(linestring):
     :return: shapely.geometry.LineString
     """
     return LineString((p[1], p[0]) for p in linestring.coords)
+
+
+def merge_linestrings(linestring_list):
+    """
+    :param linestring_list: ordered list of shapely.geometry.Linestring objects.
+    Assumes lines are contiguous. If they are not, will results in a MultiLineString
+    :return:
+    """
+    multi_line = MultiLineString(linestring_list)
+    return linemerge(multi_line)
 
 
 def decode_polyline_to_shapely_linestring(_polyline):

--- a/notebooks/7. Visualising Network.ipynb
+++ b/notebooks/7. Visualising Network.ipynb
@@ -398,6 +398,9 @@
     "        - `trips_per_day_per_service.csv` - Number of trips made by each `Service` object, complete with mode and huma-readable name if present. (This is an aggregation of the `Route` level output, as each Service is a list of `Route`s)\n",
     "        - `trips_per_day_per_route_aggregated_per_stop_id_pair.csv` - pairs of stops that exist as end-points of `Route`s. Number of trains between those stops per mode, a record of `Route`s in common. Respects stop IDs, human-readable names included but can be repeated if there are more stops in `Schedule` with the same name (common for bigger stations). There is no directionality to the column names `station_A` and `station_B`. The number given is between `station_A` and `station_B` and `station_B` and `station_A` w.r.t ID. Data is not repeated, it could be that if an expected station is not in `station_A` column, it's in the `station_B` column instead.\n",
     "        - `trips_per_day_per_route_aggregated_per_stop_name_pair.csv` - The same as `trips_per_day_per_route_aggregated_per_stop_id_pair.csv`, but aggregated by stop names, so does not respect stop IDs. Again, The number given is between `station_A_name` and `station_B_name` and `station_B_name` and `station_A_name` w.r.t stop names. Data is not repeated, it could be that if an expected station is not in `station_A_name` column, it's in the `station_B_name` column instead.\n",
+    "        \n",
+    "- **routing** related\n",
+    "    - `schedule_network_routes_geodataframe.geojson` - GeoJSON output, rows exist for each `Route` that has non empty `route` attribute - links in the network referring to the network route of that `Route`. The geometry is a combined geometry of all links referenced in the route. Columns/Fields relating to corresponding service, route IDs and mode, as well as human-readable name (if available) are included.\n",
     "\n",
     "You can also generate standard outputs for schedule only:"
    ]

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -1882,7 +1882,7 @@ def test_generating_pt_network_route_geodataframe():
     correct_gdf = gpd.GeoDataFrame(
             {'service_id': {0: 'service'}, 'route_id': {0: 'service_0'}, 'mode': {0: 'bus'},
              'route_short_name': {0: 'route'}, 'geometry': {0: LineString([(1,1), (2,2), (1,1)])}},
-        )
+        ).set_crs(n.epsg)
     correct_gdf.columns.name = 0
 
     assert_geodataframe_equal(

--- a/tests/test_outputs_handler_geojson.py
+++ b/tests/test_outputs_handler_geojson.py
@@ -133,24 +133,24 @@ def test_generating_standard_outputs(network, tmpdir):
                 routes=[
                     Route(id='1', route_short_name='', mode='bus',
                           stops=[
-                              Stop(id='0', x=529455.7452394223, y=182401.37630677427, epsg='epsg:27700', linkRefId='1'),
-                              Stop(id='1', x=529350.7866124967, y=182388.0201078112, epsg='epsg:27700', linkRefId='2')],
+                              Stop(id='0', x=529455.7452394223, y=182401.37630677427, epsg='epsg:27700', linkRefId='link_1'),
+                              Stop(id='1', x=529350.7866124967, y=182388.0201078112, epsg='epsg:27700', linkRefId='link_2')],
                           trips={'trip_id': ['VJ00938baa194cee94700312812d208fe79f3297ee_04:40:00'],
                                  'trip_departure_time': ['04:40:00'],
                                  'vehicle_id': ['veh_1_bus']},
                           arrival_offsets=['00:00:00', '00:02:00'],
                           departure_offsets=['00:00:00', '00:02:00'],
-                          route=['1', '2']),
+                          route=['link_1', 'link_2']),
                     Route(id='2', route_short_name='route2', mode='bus',
                           stops=[
-                              Stop(id='0', x=529455.7452394223, y=182401.37630677427, epsg='epsg:27700', linkRefId='1'),
-                              Stop(id='1', x=529350.7866124967, y=182388.0201078112, epsg='epsg:27700', linkRefId='2')],
+                              Stop(id='0', x=529455.7452394223, y=182401.37630677427, epsg='epsg:27700', linkRefId='link_1'),
+                              Stop(id='1', x=529350.7866124967, y=182388.0201078112, epsg='epsg:27700', linkRefId='link_2')],
                           trips={'trip_id': ['1_05:40:00', '2_05:45:00', '3_05:50:00', '4_06:40:00', '5_06:46:00'],
                                  'trip_departure_time': ['05:40:00', '05:45:00', '05:50:00', '06:40:00', '06:46:00'],
                                  'vehicle_id': ['veh_2_bus', 'veh_3_bus', 'veh_4_bus', 'veh_5_bus', 'veh_6_bus']},
                           arrival_offsets=['00:00:00', '00:03:00'],
                           departure_offsets=['00:00:00', '00:05:00'],
-                          route=['1', '2'])
+                          route=['link_1', 'link_2'])
                 ]),
         Service(id='rail_service',
                 routes=[Route(
@@ -172,7 +172,8 @@ def test_generating_standard_outputs(network, tmpdir):
                                        'network_nodes_geometry_only.geojson', 'network_links.geojson',
                                        'network_links_geometry_only.geojson', 'schedule_nodes.geojson',
                                        'schedule_nodes_geometry_only.geojson', 'schedule', 'network_nodes.geojson',
-                                       'schedule_links.geojson', 'network_change_log.csv', 'schedule_change_log.csv'}
+                                       'schedule_links.geojson', 'network_change_log.csv', 'schedule_change_log.csv',
+                                       'routing'}
     assert set(os.listdir(os.path.join(tmpdir, 'graph'))) == {'car_capacity_subgraph.geojson',
                                                               'car_freespeed_subgraph.geojson',
                                                               'car_osm_highway_unclassified.geojson',
@@ -242,4 +243,6 @@ def test_generating_standard_outputs(network, tmpdir):
     'schedule_subgraph_links_bus.dbf', 'schedule_subgraph_links_bus.shp', 'schedule_subgraph_links_rail.prj',
     'schedule_subgraph_nodes_bus.shx', 'schedule_subgraph_links_bus.cpg', 'schedule_subgraph_nodes_bus.shp',
     'schedule_subgraph_nodes_rail.cpg', 'schedule_subgraph_nodes_rail.shp'}
+
+    assert set(os.listdir(os.path.join(tmpdir, 'routing'))) == {'shp_files', 'schedule_network_routes_geodataframe.geojson'}
     assert os.path.exists(tmpdir + '.zip')

--- a/tests/test_utils_spatial.py
+++ b/tests/test_utils_spatial.py
@@ -7,7 +7,7 @@ from pyproj import Geod
 from genet.utils import spatial
 from genet import Network
 from tests.fixtures import *
-from shapely.geometry import LineString, Polygon, Point
+from shapely.geometry import LineString, Polygon, Point, MultiLineString
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 test_geojson = os.path.abspath(
@@ -42,6 +42,16 @@ def test_decode_polyline_to_s2_points():
 
 def test_swaping_x_y_in_linestring():
     assert spatial.swap_x_y_in_linestring(LineString([(1, 2), (3, 4), (5, 6)])) == LineString([(2, 1), (4, 3), (6, 5)])
+
+
+def test_merging_contiguous_linestrings():
+    linestrings = [LineString([(1, 2), (3, 4), (5, 6)]), LineString([(5,6), (7, 8), (9, 10)])]
+    assert spatial.merge_linestrings(linestrings) == LineString([(1, 2), (3, 4), (5, 6), (7, 8), (9, 10)])
+
+
+def test_merging_noncontiguous_linestrings_results_in_multilinestring():
+    linestrings = [LineString([(1, 2), (3, 4), (5, 6)]), LineString([(7, 8), (9, 10)])]
+    assert spatial.merge_linestrings(linestrings) == MultiLineString([[(1, 2), (3, 4), (5, 6)],[(7, 8), (9, 10)]])
 
 
 def test_compute_average_proximity_to_polyline():


### PR DESCRIPTION
Adds method to generate geodataframes of PT routes which take geometries from network links referenced in their routes.
So we can generate pretty pictures like the one below. Also added to standard outputs, useful for validation. The geodataframe has mode, service and route id columns for easy subsetting, as well as route names for human ease.
![market_town_bus_routes_global_routes_backgroud](https://user-images.githubusercontent.com/36536946/131151201-cc89f3a4-065d-4767-865c-fdbe968c0380.png)
