### PR TITLE
Make S3 code bucket a CI build variable

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -46,6 +46,8 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-1
     - name: Push zip to S3
+      env:
+        AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
       run: |
         echo $GITHUB_REPOSITORY
         echo $GITHUB_SHA

--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -62,7 +62,7 @@ jobs:
         zip -r app.zip .
         repo_slug=`echo $GITHUB_REPOSITORY | awk -F '/' '{print $2}'`
         echo $repo_slug
-        aws s3 cp app.zip s3://arup-arup-ukimea-tcs-dev-test-code/$repo_slug.zip
+        aws s3 cp app.zip "s3://$AWS_S3_CODE_BUCKET/$repo_slug.zip"
     - name: Send build success notification
       if: success()
       uses: rtCamp/action-slack-notify@v2.0.0


### PR DESCRIPTION
Confirmed that the code bundles are still being pushed to S3 after the change (see the timestamp of the first zip file in the bucket, pushed by the build from this branch):

```bash

2021-09-06 10:02:09   12519807 c3JV2xc.zip
2021-08-27 21:41:44   12510767 V4WdWwF.zip
2021-08-27 21:38:43   12526325 s7iXEiJ.zip
2021-08-27 21:20:42   12527411 sfSWlJj.zip
...
```