### PR TITLE
Fix runtime warnings

### DIFF
--- a/bash_scripts/code-coverage.sh
+++ b/bash_scripts/code-coverage.sh
@@ -5,7 +5,7 @@ set -e
 pushd "${0%/*}"
 pushd ..
 
-python3 -m pytest -n 24 -vv \
+python3 -m pytest -n auto -vv \
 --cov=. \
 --cov-report=html:reports/coverage \
 --cov-report=xml:reports/coverage/coverage.xml \

--- a/genet/core.py
+++ b/genet/core.py
@@ -188,7 +188,8 @@ class Network:
             e.g. {'attributes': {'osm:way:name': 'text'}}
         :return: pandas.Series
         """
-        return pd.Series(graph_operations.get_attribute_data_under_key(self.nodes(), key))
+        data = graph_operations.get_attribute_data_under_key(self.nodes(), key)
+        return pd.Series(data, dtype=graph_operations.get_pandas_dtype(data))
 
     def node_attribute_data_under_keys(self, keys: Union[list, set], index_name=None):
         """

--- a/genet/core.py
+++ b/genet/core.py
@@ -20,6 +20,7 @@ import genet.outputs_handler.matsim_xml_writer as matsim_xml_writer
 import genet.outputs_handler.sanitiser as sanitiser
 import genet.schedule_elements as schedule_elements
 import genet.utils.dict_support as dict_support
+import genet.utils.pandas_helpers as pd_helpers
 import genet.utils.graph_operations as graph_operations
 import genet.utils.parallel as parallel
 import genet.utils.persistence as persistence
@@ -189,7 +190,7 @@ class Network:
         :return: pandas.Series
         """
         data = graph_operations.get_attribute_data_under_key(self.nodes(), key)
-        return pd.Series(data, dtype=graph_operations.get_pandas_dtype(data))
+        return pd.Series(data, dtype=pd_helpers.get_pandas_dtype(data))
 
     def node_attribute_data_under_keys(self, keys: Union[list, set], index_name=None):
         """
@@ -622,7 +623,7 @@ class Network:
         # end with updated links_and_attributes dict
         add_to_link_id_mapping = df_links[['from', 'to', 'multi_edge_idx']].T.to_dict()
         df_links = df_links.drop('multi_edge_idx', axis=1)
-        links_and_attributes = {_id: {k: v for k, v in m.items() if dict_support.notna(v)} for _id, m in
+        links_and_attributes = {_id: {k: v for k, v in m.items() if pd_helpers.notna(v)} for _id, m in
                                 df_links.T.to_dict().items()}
 
         # update link_id_mapping

--- a/genet/core.py
+++ b/genet/core.py
@@ -144,8 +144,7 @@ class Network:
         self.apply_attributes_to_nodes(new_nodes_attribs)
 
         # reproject geometries
-        gdf_geometries = gpd.GeoDataFrame(self.link_attribute_data_under_keys(['geometry']))
-        gdf_geometries.crs = self.epsg
+        gdf_geometries = gpd.GeoDataFrame(self.link_attribute_data_under_keys(['geometry']), crs=self.epsg)
         gdf_geometries = gdf_geometries.to_crs(new_epsg)
         new_link_attribs = gdf_geometries.T.to_dict()
         self.apply_attributes_to_links(new_link_attribs)

--- a/genet/core.py
+++ b/genet/core.py
@@ -35,7 +35,7 @@ class Network:
     def __init__(self, epsg):
         self.epsg = epsg
         self.transformer = Transformer.from_crs(epsg, 'epsg:4326', always_xy=True)
-        self.graph = nx.MultiDiGraph(name='Network graph', crs={'init': self.epsg}, simplified=False)
+        self.graph = nx.MultiDiGraph(name='Network graph', crs=self.epsg, simplified=False)
         self.schedule = schedule_elements.Schedule(epsg)
         self.change_log = change_log.ChangeLog()
         self.spatial_tree = spatial.SpatialTree()
@@ -152,7 +152,7 @@ class Network:
         if self.schedule:
             self.schedule.reproject(new_epsg, processes)
         self.initiate_crs_transformer(new_epsg)
-        self.graph.graph['crs'] = {'init': self.epsg}
+        self.graph.graph['crs'] = self.epsg
 
     def initiate_crs_transformer(self, epsg):
         self.epsg = epsg

--- a/genet/inputs_handler/gtfs_reader.py
+++ b/genet/inputs_handler/gtfs_reader.py
@@ -168,7 +168,7 @@ def gtfs_db_to_schedule_graph(stop_times_db, stops_db, trips_db, routes_db, serv
     df = df.groupby(['service_id']).apply(generate_routes)
 
     g = nx.DiGraph(name='Schedule graph')
-    g.graph['crs'] = {'init': 'epsg:4326'}
+    g.graph['crs'] = 'epsg:4326'
     g.graph['route_to_service_map'] = df.set_index('route_id')['service_id'].T.to_dict()
     g.graph['service_to_route_map'] = df.groupby('service_id')['route_id'].apply(list).to_dict()
     g.graph['change_log'] = change_log.ChangeLog()

--- a/genet/inputs_handler/read.py
+++ b/genet/inputs_handler/read.py
@@ -43,7 +43,7 @@ def read_matsim_network(path_to_network: str, epsg: str):
     n.graph, n.link_id_mapping, duplicated_nodes, duplicated_links = \
         matsim_reader.read_network(path_to_network, n.transformer)
     n.graph.graph['name'] = 'Network graph'
-    n.graph.graph['crs'] = {'init': n.epsg}
+    n.graph.graph['crs'] = n.epsg
     if 'simplified' not in n.graph.graph:
         n.graph.graph['simplified'] = False
 

--- a/genet/outputs_handler/geojson.py
+++ b/genet/outputs_handler/geojson.py
@@ -31,7 +31,7 @@ def generate_geodataframes(graph):
         return LineString(
             [(float(from_node['x']), float(from_node['y'])), (float(to_node['x']), float(to_node['y']))])
 
-    crs = graph.graph['crs']['init']
+    crs = graph.graph['crs']
 
     node_ids, data = zip(*graph.nodes(data=True))
     geometry = [Point(float(d['x']), float(d['y'])) for d in data]

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -44,10 +44,10 @@ class ScheduleElement:
     def __init__(self):
         # check if in graph first
         if 'crs' in self._graph.graph:
-            self.epsg = self._graph.graph['crs']['init']
+            self.epsg = self._graph.graph['crs']
         else:
             self.epsg = self.find_epsg()
-            self._graph.graph['crs'] = {'init': self.epsg}
+            self._graph.graph['crs'] = self.epsg
 
     def _surrender_to_graph(self):
         d = deepcopy(self.__dict__)
@@ -177,7 +177,7 @@ class ScheduleElement:
 
     def find_epsg(self):
         if 'crs' in self._graph.graph:
-            return self._graph.graph['crs']['init']
+            return self._graph.graph['crs']
         else:
             epsg = list({d for k, d in dict(self._graph.nodes(data='epsg', default='')).items()} - {''})
             if epsg:
@@ -1060,7 +1060,7 @@ class Schedule(ScheduleElement):
             self._graph = _graph
             if epsg == '':
                 try:
-                    epsg = self._graph.graph['crs']['init']
+                    epsg = self._graph.graph['crs']
                 except KeyError:
                     raise UndefinedCoordinateSystemError(
                         'You need to specify the coordinate system for the schedule')
@@ -1375,7 +1375,7 @@ class Schedule(ScheduleElement):
         :return:
         """
         ScheduleElement.reproject(self, new_epsg, processes=processes)
-        self._graph.graph['crs'] = {'init': new_epsg}
+        self._graph.graph['crs'] = new_epsg
 
     def find_epsg(self):
         return self.init_epsg

--- a/genet/utils/dict_support.py
+++ b/genet/utils/dict_support.py
@@ -1,6 +1,5 @@
-import pandas as pd
-from numpy import ndarray
 from typing import Union
+
 import genet.utils.graph_operations as graph_operations
 
 

--- a/genet/utils/dict_support.py
+++ b/genet/utils/dict_support.py
@@ -110,10 +110,3 @@ def combine_edge_data_lists(l1, l2):
     """
     edges = merge_complex_dictionaries({(u, v): dat for u, v, dat in l1}, {(u, v): dat for u, v, dat in l2})
     return [(u, v, dat) for (u, v), dat in edges.items()]
-
-
-def notna(value):
-    nn = pd.notna(value)
-    if isinstance(nn, ndarray):
-        return any(nn)
-    return nn

--- a/genet/utils/graph_operations.py
+++ b/genet/utils/graph_operations.py
@@ -7,6 +7,7 @@ from anytree import Node, RenderTree
 
 from genet.utils import pandas_helpers as pd_helpers
 
+
 class Filter:
     """
     Helps filtering on specified attributes

--- a/genet/utils/graph_operations.py
+++ b/genet/utils/graph_operations.py
@@ -5,6 +5,7 @@ from typing import Union, Dict, Callable, Iterable
 import pandas as pd
 from anytree import Node, RenderTree
 
+from genet.utils import pandas_helpers as pd_helpers
 
 class Filter:
     """
@@ -260,7 +261,7 @@ def build_attribute_dataframe(iterator, keys: Union[list, str], index_name: str 
             name = key
 
         attribute_data = get_attribute_data_under_key(iterator, key)
-        col_series = pd.Series(attribute_data, dtype=get_pandas_dtype(attribute_data))
+        col_series = pd.Series(attribute_data, dtype=pd_helpers.get_pandas_dtype(attribute_data))
         col_series.name = name
 
         if df is not None:
@@ -270,18 +271,6 @@ def build_attribute_dataframe(iterator, keys: Union[list, str], index_name: str 
     if index_name:
         df.index = df.index.set_names([index_name])
     return df
-
-
-def get_pandas_dtype(dict):
-    pandas_dtype = object
-    if dict:
-        first_value = list(dict.values())[0]
-        python_type = type(first_value)
-        if python_type is int:
-            pandas_dtype = pd.Int64Dtype.type
-        if python_type is float:
-            pandas_dtype = pd.Float64Dtype.type
-    return pandas_dtype
 
 
 def apply_to_attributes(iterator, to_apply, location):

--- a/genet/utils/graph_operations.py
+++ b/genet/utils/graph_operations.py
@@ -1,8 +1,9 @@
-from typing import Union, Dict, Callable, Iterable
-from anytree import Node, RenderTree
-import pandas as pd
 import logging
 from itertools import count, filterfalse
+from typing import Union, Dict, Callable, Iterable
+
+import pandas as pd
+from anytree import Node, RenderTree
 
 
 class Filter:
@@ -213,7 +214,7 @@ def get_attribute_data_under_key(iterator: Iterable, key: Union[str, dict]):
     :param iterator: list or iterator yielding (index, attribute_dictionary)
     :param key: either a string e.g. 'modes', or if accessing nested information, a dictionary
         e.g. {'attributes': {'osm:way:name': 'text'}}
-    :return: dictionary where keys are indicies and values are data stored under the key
+    :return: dictionary where keys are indices and values are data stored under the key
     """
 
     def get_the_data(attributes, key):
@@ -258,7 +259,8 @@ def build_attribute_dataframe(iterator, keys: Union[list, str], index_name: str 
         else:
             name = key
 
-        col_series = pd.Series(get_attribute_data_under_key(iterator, key))
+        attribute_data = get_attribute_data_under_key(iterator, key)
+        col_series = pd.Series(attribute_data, dtype=get_pandas_dtype(attribute_data))
         col_series.name = name
 
         if df is not None:
@@ -268,6 +270,18 @@ def build_attribute_dataframe(iterator, keys: Union[list, str], index_name: str 
     if index_name:
         df.index = df.index.set_names([index_name])
     return df
+
+
+def get_pandas_dtype(dict):
+    pandas_dtype = object
+    if dict:
+        first_value = list(dict.values())[0]
+        python_type = type(first_value)
+        if python_type is int:
+            pandas_dtype = pd.Int64Dtype.type
+        if python_type is float:
+            pandas_dtype = pd.Float64Dtype.type
+    return pandas_dtype
 
 
 def apply_to_attributes(iterator, to_apply, location):

--- a/genet/utils/pandas_helpers.py
+++ b/genet/utils/pandas_helpers.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from numpy import ndarray
+
+
+def notna(value):
+    nn = pd.notna(value)
+    if isinstance(nn, ndarray):
+        return any(nn)
+    return nn
+
+
+def get_pandas_dtype(dict):
+    pandas_dtype = object
+    if dict:
+        first_value = list(dict.values())[0]
+        python_type = type(first_value)
+        if python_type is int:
+            pandas_dtype = pd.Int64Dtype.type
+        if python_type is float:
+            pandas_dtype = pd.Float64Dtype.type
+    return pandas_dtype

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ numpy>=1.18.4
 osmnx==0.15.0
 osmread @ git+https://github.com/dezhin/osmread.git@d8d3fe5edd15fdab9526ea7a100ee6c796315663#egg=osmread-0.2.dev0
 packaging==20.4
-pandas>=1.0.3
+pandas==1.3.3
 parso==0.7.0
 pexpect==4.8.0
 pickleshare==0.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,8 +54,8 @@ py>=1.8.1
 Pygments==2.7.4
 pyparsing==2.4.7
 pyproj>=3.1.0
-pytest>=5.4.2
-pytest-cov>=2.8.1
+pytest==6.2.5
+pytest-cov==2.12.1
 pytest-mock==3.1.0
 pytest-xdist==2.3.0
 python-dateutil==2.8.1

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -312,7 +312,7 @@ def correct_schedule_graph_edges_from_test_gtfs():
 
 @pytest.fixture()
 def correct_schedule_graph_data_from_test_gtfs():
-    return {'name': 'Schedule graph', 'crs': {'init': 'epsg:4326'},
+    return {'name': 'Schedule graph', 'crs': 'epsg:4326',
             'route_to_service_map': {'1001_0': '1001', '1002_0': '1002'},
             'service_to_route_map': {'1001': ['1001_0'], '1002': ['1002_0']}, 'change_log': change_log.ChangeLog(),
             'routes': {'1001_0': {'arrival_offsets': ['00:00:00', '00:02:00'], 'route_color': 'CE312D',

--- a/tests/test_core_components_route.py
+++ b/tests/test_core_components_route.py
@@ -79,7 +79,7 @@ def test_initiating_route(route):
               'arrival_offsets': ['00:00:00', '00:03:00', '00:07:00', '00:13:00'],
               'departure_offsets': ['00:00:00', '00:05:00', '00:09:00', '00:15:00'], 'route_long_name': '', 'id': '1',
               'route': ['1', '2', '3', '4'], 'await_departure': [], 'ordered_stops': ['1', '2', '3', '4']}},
-                                               'services': {}, 'crs': {'init': 'epsg:27700'}})
+                                               'services': {}, 'crs': 'epsg:27700'})
 
 
 def test__repr__shows_stops_and_trips_length(route):

--- a/tests/test_core_components_service.py
+++ b/tests/test_core_components_service.py
@@ -123,7 +123,7 @@ def test_initiating_service(service):
                                    'service': {'id': 'service', 'name': 'name'}},
                                'route_to_service_map': {'1': 'service', '2': 'service'},
                                'service_to_route_map': {'service': ['1', '2']},
-                               'crs': {'init': 'epsg:27700'}})
+                               'crs': 'epsg:27700'})
 
 
 def test__repr__shows_route_length(service):

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -190,7 +190,7 @@ def test_reproject_delegates_reprojection_to_schedules_own_method(network1, rout
 
 def test_reproject_updates_graph_crs(network1):
     network1.reproject('epsg:4326')
-    assert network1.graph.graph['crs'] == {'init': 'epsg:4326'}
+    assert network1.graph.graph['crs'] == 'epsg:4326'
 
 
 def test_reprojecting_links_with_geometries():

--- a/tests/test_core_schedule.py
+++ b/tests/test_core_schedule.py
@@ -1,19 +1,18 @@
-import os
-import sys
-import pytest
 from shapely.geometry import Polygon, GeometryCollection
 from pandas import DataFrame, Timestamp
 from pandas.testing import assert_frame_equal
-from tests.fixtures import *
-from tests.test_core_components_route import self_looping_route, route
-from tests.test_core_components_service import service
-from genet.inputs_handler import matsim_reader, gtfs_reader
+from shapely.geometry import Polygon, GeometryCollection
+
+from genet.exceptions import ServiceIndexError, ConflictingStopData, InconsistentVehicleModeError
 from genet.inputs_handler import read
 from genet.schedule_elements import Schedule, Service, Route, Stop, read_vehicle_types
 from genet.utils import plot, spatial
 from genet.validate import schedule_validation
-from genet.exceptions import ServiceIndexError, RouteIndexError, StopIndexError, UndefinedCoordinateSystemError, \
-    ConflictingStopData, InconsistentVehicleModeError
+from tests.fixtures import *
+from tests.test_core_components_service import service
+from tests.test_core_components_route import self_looping_route, route
+
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 pt2matsim_schedule_file = os.path.abspath(
@@ -1483,9 +1482,7 @@ def test_writing_schedule_to_json(schedule, json_schedule, tmpdir):
 
 def test_transforming_schedule_to_gtfs(schedule):
     gtfs = schedule.to_gtfs(gtfs_day='19700101')
-    assert_semantically_equal(
-        gtfs['stops'].to_dict(),
-        {'stop_id': {'5': '5', '6': '6', '7': '7', '8': '8', '3': '3', '2': '2', '4': '4', '1': '1'},
+    expected_stops = {'stop_id': {'5': '5', '6': '6', '7': '7', '8': '8', '3': '3', '2': '2', '4': '4', '1': '1'},
          'stop_name': {'5': '', '6': '', '7': '', '8': '', '3': '', '2': '', '4': '', '1': ''},
          'stop_lat': {'5': 49.76682779861249, '6': 49.766825803756994, '7': 49.76683608549253, '8': 49.766856648946295,
                       '3': 49.76683608549253, '2': 49.766825803756994, '4': 49.766856648946295, '1': 49.76682779861249},
@@ -1511,15 +1508,16 @@ def test_transforming_schedule_to_gtfs(schedule):
                       '2': float('nan'), '4': float('nan'), '1': float('nan')},
          'platform_code': {'5': float('nan'), '6': float('nan'), '7': float('nan'), '8': float('nan'),
                            '3': float('nan'), '2': float('nan'), '4': float('nan'), '1': float('nan')}}
-    )
-    assert_semantically_equal(
-        gtfs['routes'].to_dict(),
-        {'route_id': {0: 'service'}, 'route_short_name': {0: 'name_2'}, 'route_long_name': {0: ''},
-         'agency_id': {0: float('nan')}, 'route_desc': {0: float('nan')}, 'route_url': {0: float('nan')},
+    actual_stops = gtfs['stops'].to_dict()
+    assert_semantically_equal(expected_stops, actual_stops)
+    expected_routes = {'route_id': {0: 'service'}, 'route_short_name': {0: 'name_2'}, 'route_long_name': {0: ''},
+         'agency_id': {0: None}, 'route_desc': {0: None}, 'route_url': {0: None},
          'route_type': {0: 3},
-         'route_color': {0: float('nan')}, 'route_text_color': {0: float('nan')}, 'route_sort_order': {0: float('nan')},
-         'continuous_pickup': {0: float('nan')}, 'continuous_drop_off': {0: float('nan')}}
-    )
+         'route_color': {0: None}, 'route_text_color': {0: None}, 'route_sort_order': {0: None},
+         'continuous_pickup': {0: None}, 'continuous_drop_off': {0: None}}
+    actual_routes = gtfs['routes'].to_dict()
+    assert_semantically_equal(expected_routes, actual_routes)
+
     assert_semantically_equal(
         gtfs['trips'].to_dict(),
         {'route_id': {0: 'service', 1: 'service', 2: 'service', 3: 'service'},

--- a/tests/test_core_schedule.py
+++ b/tests/test_core_schedule.py
@@ -138,7 +138,7 @@ def test_initiating_schedule(schedule):
                                'services': {'service': {'id': 'service', 'name': 'name'}},
                                'route_to_service_map': {'1': 'service', '2': 'service'},
                                'service_to_route_map': {'service': ['1', '2']},
-                               'crs': {'init': 'epsg:27700'}})
+                               'crs': 'epsg:27700'})
 
 
 def test_initiating_schedule_with_non_uniquely_indexed_objects():

--- a/tests/test_core_schedule_elements.py
+++ b/tests/test_core_schedule_elements.py
@@ -98,7 +98,7 @@ def schedule_graph():
                   'service1': {'id': 'service1', 'name': 'route1'}},
         route_to_service_map={'1': 'service1', '2': 'service1', '3': 'service2', '4': 'service2'},
         service_to_route_map={'service1': ['1', '2'], 'service2': ['3', '4']},
-        crs={'init': 'epsg:27700'}
+        crs='epsg:27700'
     )
     nodes = {'4': {'services': ['service2'], 'routes': ['3', '4'], 'id': '4', 'x': 529350.7866124967,
                    'y': 182388.0201078112, 'epsg': 'epsg:27700', 'name': '', 'lat': 51.52560003323918,
@@ -362,6 +362,7 @@ def service_with_loopy_routes():
                                 arrival_offsets=['', '', ''],
                                 departure_offsets=['', '', '']),
                       ])
+
 
 def test_splitting_service_on_direction_with_loopy_routes(service_with_loopy_routes):
     service_split = service_with_loopy_routes.split_by_direction()

--- a/tests/test_data/matsim/network.xml
+++ b/tests/test_data/matsim/network.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE network SYSTEM "http://www.matsim.org/files/dtd/network_v2.dtd">
 <network>
 	<attributes>
-		<attribute name="crs" class="java.lang.String">{'init': 'epsg:27700'}</attribute>
+		<attribute name="crs" class="java.lang.String">epsg:27700</attribute>
 		<attribute name="simplified" class="java.lang.String">False</attribute>
 	</attributes>
     <nodes>

--- a/tests/test_inputs_read.py
+++ b/tests/test_inputs_read.py
@@ -59,7 +59,7 @@ def test_reading_json():
                          'route': ['1', '10'],
                          'await_departure': [True, True],
                          'ordered_stops': ['490000235X.link:1', '490000235YB.link:10']}},
-         'services': {'20274': {'id': '20274', 'name': 'N55'}}, 'crs': {'init': 'epsg:27700'}}
+         'services': {'20274': {'id': '20274', 'name': 'N55'}}, 'crs': 'epsg:27700'}
     )
     assert_semantically_equal(
         dict(n.schedule._graph.nodes(data=True)),

--- a/tests/test_utils_graph_operations.py
+++ b/tests/test_utils_graph_operations.py
@@ -3,6 +3,7 @@ from genet.utils import graph_operations
 from anytree import Node, RenderTree
 from tests.fixtures import assert_semantically_equal
 import logging
+import pandas as pd
 from pandas.testing import assert_frame_equal
 from pandas import DataFrame
 
@@ -649,3 +650,23 @@ def test_convert_list_of_link_ids_to_network_nodes_with_disconnected_link_id_lis
     network_nodes = graph_operations.convert_list_of_link_ids_to_network_nodes(n, ['0', '2'])
 
     assert network_nodes == [[1, 2], [3, 4]]
+
+
+def test_uses_object_dtype_for_empty_dictionary():
+    dtype = graph_operations.get_pandas_dtype({})
+    assert dtype is object
+
+
+def test_uses_int64_dtype_for_dictionary_with_integral_values():
+    dtype = graph_operations.get_pandas_dtype({'number': 42})
+    assert dtype is pd.Int64Dtype.type
+
+
+def test_uses_int64_dtype_for_dictionary_with_floating_point_values():
+    dtype = graph_operations.get_pandas_dtype({'number': 42.42})
+    assert dtype is pd.Float64Dtype.type
+
+
+def test_uses_object_dtype_for_dictionary_with_list_values():
+    dtype = graph_operations.get_pandas_dtype({'numbers': [42, 101, -1]})
+    assert dtype is object

--- a/tests/test_utils_graph_operations.py
+++ b/tests/test_utils_graph_operations.py
@@ -662,7 +662,7 @@ def test_uses_int64_dtype_for_dictionary_with_integral_values():
     assert dtype is pd.Int64Dtype.type
 
 
-def test_uses_int64_dtype_for_dictionary_with_floating_point_values():
+def test_uses_float64_dtype_for_dictionary_with_floating_point_values():
     dtype = graph_operations.get_pandas_dtype({'number': 42.42})
     assert dtype is pd.Float64Dtype.type
 

--- a/tests/test_utils_graph_operations.py
+++ b/tests/test_utils_graph_operations.py
@@ -650,23 +650,3 @@ def test_convert_list_of_link_ids_to_network_nodes_with_disconnected_link_id_lis
     network_nodes = graph_operations.convert_list_of_link_ids_to_network_nodes(n, ['0', '2'])
 
     assert network_nodes == [[1, 2], [3, 4]]
-
-
-def test_uses_object_dtype_for_empty_dictionary():
-    dtype = graph_operations.get_pandas_dtype({})
-    assert dtype is object
-
-
-def test_uses_int64_dtype_for_dictionary_with_integral_values():
-    dtype = graph_operations.get_pandas_dtype({'number': 42})
-    assert dtype is pd.Int64Dtype.type
-
-
-def test_uses_float64_dtype_for_dictionary_with_floating_point_values():
-    dtype = graph_operations.get_pandas_dtype({'number': 42.42})
-    assert dtype is pd.Float64Dtype.type
-
-
-def test_uses_object_dtype_for_dictionary_with_list_values():
-    dtype = graph_operations.get_pandas_dtype({'numbers': [42, 101, -1]})
-    assert dtype is object

--- a/tests/test_utils_pandas_helpers.py
+++ b/tests/test_utils_pandas_helpers.py
@@ -1,0 +1,22 @@
+from genet.utils import pandas_helpers
+from pandas import Int64Dtype, Float64Dtype
+
+
+def test_uses_object_dtype_for_empty_dictionary():
+    dtype = pandas_helpers.get_pandas_dtype({})
+    assert dtype is object
+
+
+def test_uses_int64_dtype_for_dictionary_with_integral_values():
+    dtype = pandas_helpers.get_pandas_dtype({'number': 42})
+    assert dtype is Int64Dtype.type
+
+
+def test_uses_float64_dtype_for_dictionary_with_floating_point_values():
+    dtype = pandas_helpers.get_pandas_dtype({'number': 42.42})
+    assert dtype is Float64Dtype.type
+
+
+def test_uses_object_dtype_for_dictionary_with_list_values():
+    dtype = pandas_helpers.get_pandas_dtype({'numbers': [42, 101, -1]})
+    assert dtype is object

--- a/tests/test_utils_spatial.py
+++ b/tests/test_utils_spatial.py
@@ -190,12 +190,15 @@ def test_SpatialTree_adds_links(network):
 
 def test_SpatialTree_closest_links_in_london_finds_links_within_30_metres(network):
     spatial_tree = spatial.SpatialTree(network)
-    stops = GeoDataFrame({
-        'id': {0: 'stop_10m_to_link_1', 1: 'stop_15m_to_link_2', 2: 'stop_20m_to_link_1'},
-        'geometry': {0: Point(-0.15186089346604492, 51.51950409732838),
-                     1: Point(-0.15164747576623197, 51.520660715220636),
-                     2: Point(-0.1520233977548685, 51.51952913606585)}})
-    stops.crs = {'init': 'epsg:4326'}
+    stops = GeoDataFrame(
+        {
+            'id': {0: 'stop_10m_to_link_1', 1: 'stop_15m_to_link_2', 2: 'stop_20m_to_link_1'},
+            'geometry': {0: Point(-0.15186089346604492, 51.51950409732838),
+                         1: Point(-0.15164747576623197, 51.520660715220636),
+                         2: Point(-0.1520233977548685, 51.51952913606585)}
+        },
+        crs='epsg:4326'
+    )
 
     closest_links = spatial_tree.closest_links(stops, 30, modes='car')
     assert_semantically_equal(closest_links.reset_index().groupby('id')['link_id'].apply(list).to_dict(),
@@ -206,12 +209,15 @@ def test_SpatialTree_closest_links_in_london_finds_links_within_30_metres(networ
 
 def test_SpatialTree_closest_links_in_london_finds_a_link_within_13_metres(network):
     spatial_tree = spatial.SpatialTree(network)
-    stops = GeoDataFrame({
-        'id': {0: 'stop_10m_to_link_1', 1: 'stop_15m_to_link_2', 2: 'stop_20m_to_link_1'},
-        'geometry': {0: Point(-0.15186089346604492, 51.51950409732838),
-                     1: Point(-0.15164747576623197, 51.520660715220636),
-                     2: Point(-0.1520233977548685, 51.51952913606585)}})
-    stops.crs = {'init': 'epsg:4326'}
+    stops = GeoDataFrame(
+        {
+            'id': {0: 'stop_10m_to_link_1', 1: 'stop_15m_to_link_2', 2: 'stop_20m_to_link_1'},
+            'geometry': {0: Point(-0.15186089346604492, 51.51950409732838),
+                         1: Point(-0.15164747576623197, 51.520660715220636),
+                         2: Point(-0.1520233977548685, 51.51952913606585)}
+        },
+        crs='epsg:4326'
+    )
 
     closest_links = spatial_tree.closest_links(stops, 13, modes='car')
     closest_links = closest_links.dropna()
@@ -229,10 +235,10 @@ def test_SpatialTree_closest_links_in_indonesia_finds_link_within_20_metres():
                    'modes': ['car']
                })
     spatial_tree = spatial.SpatialTree(n)
-    stops = GeoDataFrame({'geometry': {
-        'stop_15m_to_link_1': Point(109.380607, 0.320333)
-    }})
-    stops.crs = {'init': 'epsg:4326'}
+    stops = GeoDataFrame(
+        {'geometry': {'stop_15m_to_link_1': Point(109.380607, 0.320333)}},
+        crs='epsg:4326'
+    )
 
     closest_links = spatial_tree.closest_links(stops, 20, modes='car')
     closest_links = closest_links.dropna()
@@ -250,10 +256,10 @@ def test_SpatialTree_closest_links_in_indonesia_doesnt_find_link_within_10_metre
                    'modes': ['car']
                })
     spatial_tree = spatial.SpatialTree(n)
-    stops = GeoDataFrame({'geometry': {
-        'stop_15m_to_link_1': Point(109.380607, 0.320333)
-    }})
-    stops.crs = {'init': 'epsg:4326'}
+    stops = GeoDataFrame(
+        {'geometry': {'stop_15m_to_link_1': Point(109.380607, 0.320333)}},
+        crs='epsg:4326'
+    )
 
     closest_links = spatial_tree.closest_links(stops, 10, modes='car')
     closest_links = closest_links.dropna()
@@ -270,10 +276,10 @@ def test_SpatialTree_closest_links_in_north_canada_finds_link_within_30_metres()
                    'modes': ['car']
                })
     spatial_tree = spatial.SpatialTree(n)
-    stops = GeoDataFrame({'geometry': {
-        'stop_15m_to_link_1': Point(-93.250971, 73.664114)
-    }})
-    stops.crs = {'init': 'epsg:4326'}
+    stops = GeoDataFrame(
+        {'geometry': {'stop_15m_to_link_1': Point(-93.250971, 73.664114)}},
+        crs='epsg:4326'
+    )
 
     closest_links = spatial_tree.closest_links(stops, 30, modes='car')
     assert_semantically_equal(closest_links.reset_index().groupby('index')['link_id'].apply(list).to_dict(),
@@ -290,10 +296,10 @@ def test_SpatialTree_closest_links_in_north_canada_doesnt_find_link_within_10_me
                    'modes': ['car']
                })
     spatial_tree = spatial.SpatialTree(n)
-    stops = GeoDataFrame({'geometry': {
-        'stop_15m_to_link_1': Point(-93.250971, 73.664114)
-    }})
-    stops.crs = {'init': 'epsg:4326'}
+    stops = GeoDataFrame(
+        {'geometry': {'stop_15m_to_link_1': Point(-93.250971, 73.664114)}},
+        crs='epsg:4326'
+    )
 
     closest_links = spatial_tree.closest_links(stops, 10, modes='car')
     closest_links = closest_links.dropna()


### PR DESCRIPTION
Closes #93 

Fixes a few hundred warnings - still a few hanging around.

I also had to bump pytest-related versions to make the parallel test stuff work on my local machine, and modified the number of processes so that it is automatically matched to the number of available processors reported by the machine.

I had a brief look at the `xfail` test, but couldn't see a quick fix for it.

#### Before
<img width="778" alt="Screen Shot 2021-09-14 at 23 59 43" src="https://user-images.githubusercontent.com/250899/133345011-df1b2f9d-b86a-48f6-b150-46057f5ba5bc.png">

#### After
<img width="1010" alt="Screen Shot 2021-09-15 at 00 00 15" src="https://user-images.githubusercontent.com/250899/133345028-99578343-a207-4dfe-b86d-2ab0f124ddb4.png">
