### PR TITLE
upgrade protobuf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ pluggy==0.13.1
 ply==3.11
 polyline==1.4.0
 prompt-toolkit==3.0.5
-protobuf==3.0.0b3
+protobuf==3.19.3
 ptyprocess==0.6.0
 py>=1.8.1
 Pyomo==5.7.3


### PR DESCRIPTION
Experienced this error installing genet using conda:

```
#8 99.66 Collecting protobuf==3.0.0b3
#8 99.84   Downloading protobuf-3.0.0b3.tar.gz (117 kB)
#8 99.92   Preparing metadata (setup.py): started
#8 100.2   Preparing metadata (setup.py): finished with status 'error'
#8 100.2   ERROR: Command errored out with exit status 1:
#8 100.2    command: /opt/conda/envs/abmenv/bin/python3.7 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-38l64av7/protobuf_acc973556ec84528a74ca21fdf0e101d/setup.py'"'"'; __file__='"'"'/tmp/pip-install-38l64av7/protobuf_acc973556ec84528a74ca21fdf0e101d/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-aswsmp7y
#8 100.2        cwd: /tmp/pip-install-38l64av7/protobuf_acc973556ec84528a74ca21fdf0e101d/
#8 100.2   Complete output (5 lines):
#8 100.2   Traceback (most recent call last):
#8 100.2     File "<string>", line 1, in <module>
#8 100.2     File "/tmp/pip-install-38l64av7/protobuf_acc973556ec84528a74ca21fdf0e101d/setup.py", line 17, in <module>
#8 100.2       from distutils.command.build_py import build_py_2to3 as _build_py
#8 100.2   ImportError: cannot import name 'build_py_2to3' from 'distutils.command.build_py' (/opt/conda/envs/abmenv/lib/python3.7/site-packages/setuptools/_distutils/command/build_py.py)
#8 100.2   ----------------------------------------
#8 100.2 WARNING: Discarding https://files.pythonhosted.org/packages/52/f8/1b0d57028ca6144a03e1fdb5eeca6bd10194dcbfc2405d920c47bb7a79ca/protobuf-3.0.0b3.tar.gz#sha256=b4f0a326f1776f874152243bea10ba924278bf76b7b9e10991c7f8d17eb71525 (from https://pypi.org/simple/protobuf/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
#8 100.2 ERROR: Could not find a version that satisfies the requirement protobuf==3.0.0b3 (from genet) (from versions: 2.0.0b0, 2.0.3, 2.3.0, 2.4.1, 2.5.0, 2.6.0, 2.6.1, 3.0.0a2, 3.0.0a3, 3.0.0b1, 3.0.0b1.post1, 3.0.0b1.post2, 3.0.0b2, 3.0.0b2.post1, 3.0.0b2.post2, 3.0.0b3, 3.0.0b4, 3.0.0, 3.1.0, 3.1.0.post1, 3.2.0rc1, 3.2.0rc1.post1, 3.2.0rc2, 3.2.0, 3.3.0, 3.4.0, 3.5.0.post1, 3.5.1, 3.5.2, 3.5.2.post1, 3.6.0, 3.6.1, 3.7.0rc2, 3.7.0rc3, 3.7.0, 3.7.1, 3.8.0rc1, 3.8.0, 3.9.0rc1, 3.9.0, 3.9.1, 3.9.2, 3.10.0rc1, 3.10.0, 3.11.0rc1, 3.11.0rc2, 3.11.0, 3.11.1, 3.11.2, 3.11.3, 3.12.0rc1, 3.12.0rc2, 3.12.0, 3.12.1, 3.12.2, 3.12.4, 3.13.0rc3, 3.13.0, 3.14.0rc1, 3.14.0rc2, 3.14.0rc3, 3.14.0, 3.15.0rc1, 3.15.0rc2, 3.15.0, 3.15.1, 3.15.2, 3.15.3, 3.15.4, 3.15.5, 3.15.6, 3.15.7, 3.15.8, 3.16.0rc1, 3.16.0rc2, 3.16.0, 3.17.0rc1, 3.17.0rc2, 3.17.0, 3.17.1, 3.17.2, 3.17.3, 3.18.0rc1, 3.18.0rc2, 3.18.0, 3.18.1, 3.19.0rc1, 3.19.0rc2, 3.19.0, 3.19.1, 3.19.2, 3.19.3, 4.0.0rc1, 4.0.0rc2)
#8 100.2 ERROR: No matching distribution found for protobuf==3.0.0b3
------
```

This version change fixes the issue without braking the build.