### PR TITLE
Fix loopy simplification

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -32,7 +32,7 @@ jobs:
         pip install -e .
     - name: Lint with flake8
       run: |
-        flake8 . --max-line-length 120 --count  --show-source --statistics --exclude=scripts,tests,notebooks
+        flake8 . --max-line-length 120 --count  --show-source --statistics --exclude=scripts,tests,notebooks,venv
     - name: Unit tests
       run: |
         export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/genet/core.py
+++ b/genet/core.py
@@ -229,11 +229,12 @@ class Network:
         pt_stop_loops = set(self.schedule.stop_attribute_data(keys=['linkRefId'])['linkRefId'])
         to_remove = loops - pt_stop_loops
         if to_remove:
-            logging.info(f'Simplification led to {len(loops)} in the network. {len(to_remove)} are not connected'
-                         'to PT stops.')
+            logging.info(f'Simplification led to {len(loops)} self-loop links in the network. '
+                         f'{len(to_remove)} are not connected to the PT stops.')
             if not keep_loops:
-                logging.info('These loops will now be removed. To disable this behaviour, use `keep_loops=True`.'
-                             'Investigate the change log for more information about these links')
+                logging.info('The self-loops with no reference to PT stops will now be removed. '
+                             'To disable this behaviour, use `keep_loops=True`. '
+                             'Investigate the change log for more information about these links.')
                 self.remove_links(to_remove)
 
         # mark graph as having been simplified

--- a/genet/core.py
+++ b/genet/core.py
@@ -217,7 +217,7 @@ class Network:
             and 1 process is often preferable --- there is overhead for splitting and joining the data.
         :param keep_loops: bool, defaults to False. Simplification often leads to self-loops, these will be removed
             unless keep_loops=True
-        :return: set of self-loop link IDs
+        :return: None, updates Network object
         """
         if self.is_simplified():
             raise RuntimeError('This network has already been simplified. You cannot simplify the graph twice.')

--- a/genet/core.py
+++ b/genet/core.py
@@ -237,11 +237,12 @@ class Network:
                              'To disable this behaviour, use `keep_loops=True`. '
                              'Investigate the change log for more information about these links.')
                 self.remove_links(useless_self_loops)
+                # delete removed links from the simplification map
+                self.link_simplification_map = {k: v for k, v in self.link_simplification_map.items() if
+                                                v not in useless_self_loops}
 
         # mark graph as having been simplified
         self.graph.graph["simplified"] = True
-
-        return useless_self_loops
 
     def is_simplified(self):
         return self.graph.graph["simplified"]

--- a/genet/core.py
+++ b/genet/core.py
@@ -231,7 +231,7 @@ class Network:
         useless_self_loops = loops - pt_stop_loops
         if useless_self_loops:
             logging.warning(f'Simplification led to {len(loops)} self-loop links in the network. '
-                         f'{len(useless_self_loops)} are not connected to the PT stops.')
+                            f'{len(useless_self_loops)} are not connected to the PT stops.')
             if not keep_loops:
                 logging.info('The self-loops with no reference to PT stops will now be removed. '
                              'To disable this behaviour, use `keep_loops=True`. '

--- a/genet/core.py
+++ b/genet/core.py
@@ -239,7 +239,7 @@ class Network:
         # mark graph as having been simplified
         self.graph.graph["simplified"] = True
 
-        return  to_remove
+        return to_remove
 
     def is_simplified(self):
         return self.graph.graph["simplified"]
@@ -546,6 +546,7 @@ class Network:
         :param mode: which mode to remove
         :return: updates graph
         """
+
         def empty_modes(mode_attrib):
             if not mode_attrib:
                 return True

--- a/genet/utils/graph_operations.py
+++ b/genet/utils/graph_operations.py
@@ -292,8 +292,8 @@ def apply_mapping_to_attributes(iterator, mapping, location):
             # to relevant items
             pass
     if (not new_attributes) and mapping:
-        logging.warning(f'Mapping attributes resulted in 0 changes. Ensure your location variable: {location} exists'
-                        f'as keys in the input dictionaries. Only dictionaries with location={location} keys will be'
+        logging.warning(f'Mapping attributes resulted in 0 changes. Ensure your location variable: {location} exists '
+                        f'as keys in the input dictionaries. Only dictionaries with location={location} keys will be '
                         'mapped.')
     return new_attributes
 

--- a/genet/utils/simplification.py
+++ b/genet/utils/simplification.py
@@ -115,7 +115,7 @@ def _is_endpoint(node_neighbours):
     return [node for node, data in node_neighbours.items() if
             ((len(data['successors'] | data['predecessors']) > 2) or
              (not data['successors'] or not data['predecessors']) or
-             (data['successors'] == {node}) or
+             (node in data['successors']) or
              (len(data['successors']) != len(data['predecessors'])) or
              ((len(data['successors'] | data['predecessors']) == 1) and (data['successors'] == data['predecessors'])))]
 

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -500,7 +500,7 @@ def test_simplifing_puma_network_results_in_correct_record_of_removed_links_and_
     assert report['schedule']['schedule_level']['is_valid_schedule']
 
 
-def test_simplify_does_not_oversimplify_endpoints():
+def test_simplify_does_not_oversimplify_PT_endpoints():
     n = read.read_matsim(path_to_network=puma_network_test_file, epsg='epsg:27700',
                          path_to_schedule=puma_schedule_test_file)
 

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -500,6 +500,20 @@ def test_simplifing_puma_network_results_in_correct_record_of_removed_links_and_
     assert report['schedule']['schedule_level']['is_valid_schedule']
 
 
+def test_simplify_does_not_oversimplify_endpoints():
+    n = read.read_matsim(path_to_network=puma_network_test_file, epsg='epsg:27700',
+                         path_to_schedule=puma_schedule_test_file)
+
+    stops_at_risk = ['5221390681543854913', '5221390302070799085', '5221390323679791901']
+    for s in stops_at_risk:
+        assert n.link(n.schedule.stop(s).linkRefId)['length'] == 1
+
+    n.simplify()
+
+    for s in stops_at_risk:
+        assert n.link(n.schedule.stop(s).linkRefId)['length'] == 1
+
+
 def test_simplified_network_saves_to_correct_dtds(tmpdir, network_dtd, schedule_dtd):
     n = read.read_matsim(path_to_network=puma_network_test_file, epsg='epsg:27700',
                          path_to_schedule=puma_schedule_test_file)

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -476,77 +476,62 @@ def test_attempt_to_simplify_already_simplified_network_throws_error():
 
 
 @pytest.fixture()
-def puma_network_pre_simplify():
+def puma_network():
     return read.read_matsim(
         path_to_network=puma_network_test_file, epsg='epsg:27700', path_to_schedule=puma_schedule_test_file)
 
 
-@pytest.fixture()
-def puma_network_post_simplify():
-    n = read.read_matsim(
-        path_to_network=puma_network_test_file, epsg='epsg:27700', path_to_schedule=puma_schedule_test_file)
-    deleted_self_loops = n.simplify()
-    return deleted_self_loops, n
+def test_simplifing_puma_network_results_in_correct_record_of_removed_links_and_expected_graph_data(puma_network):
+    assert not puma_network.is_simplified()
+    link_ids_pre_simplify = set(dict(puma_network.links()).keys())
 
+    deleted_self_loops = puma_network.simplify()
+    assert puma_network.is_simplified()
 
-def test_simplifing_puma_network_results_in_correct_record_of_removed_links_and_expected_graph_data(
-        puma_network_pre_simplify, puma_network_post_simplify):
-    n = puma_network_pre_simplify
-
-    link_ids_pre_simplify = set(dict(n.links()).keys())
-
-    deleted_self_loops, n = puma_network_post_simplify
-    assert n.is_simplified()
-
-    link_ids_post_simplify = set(dict(n.links()).keys())
+    link_ids_post_simplify = set(dict(puma_network.links()).keys())
 
     assert link_ids_post_simplify & link_ids_pre_simplify
     new_links = link_ids_post_simplify - link_ids_pre_simplify
     deleted_links = link_ids_pre_simplify - link_ids_post_simplify
     # check the links removed in simplification are all mapped to new links
-    assert set(n.link_simplification_map.keys()) == deleted_links
+    assert set(puma_network.link_simplification_map.keys()) == deleted_links
     # check even the removed loop links have the simplification mapping retained
-    assert set(n.link_simplification_map.values()) == new_links | deleted_self_loops
+    assert set(puma_network.link_simplification_map.values()) == new_links | deleted_self_loops
     # check all new links int he network have edge mappings
-    assert (set(n.link_id_mapping.keys()) & new_links) == new_links
+    assert (set(puma_network.link_id_mapping.keys()) & new_links) == new_links
 
-    report = n.generate_validation_report()
+    report = puma_network.generate_validation_report()
 
     assert report['routing']['services_have_routes_in_the_graph']
     assert report['schedule']['schedule_level']['is_valid_schedule']
 
 
-def test_simplify_does_not_oversimplify_PT_endpoints(
-        puma_network_pre_simplify, puma_network_post_simplify):
-    n = puma_network_pre_simplify
-
+def test_simplify_does_not_oversimplify_PT_endpoints(puma_network):
+    assert not puma_network.is_simplified()
     stops_at_risk = ['5221390681543854913', '5221390302070799085', '5221390323679791901']
     for s in stops_at_risk:
-        assert n.link(n.schedule.stop(s).linkRefId)['length'] == 1
+        assert puma_network.link(puma_network.schedule.stop(s).linkRefId)['length'] == 1
 
-    deleted_self_loops, n = puma_network_post_simplify
+    deleted_self_loops = puma_network.simplify()
 
     for s in stops_at_risk:
-        assert n.link(n.schedule.stop(s).linkRefId)['length'] == 1
+        assert puma_network.link(puma_network.schedule.stop(s).linkRefId)['length'] == 1
 
 
-def test_simplify_removes_loops_by_default_but_keeps_pt_stop_loops(
-        puma_network_pre_simplify, puma_network_post_simplify):
-    n = puma_network_pre_simplify
-
-    assert n.schedule.stop('5221390681543854913').linkRefId == '5221390681543854913_5221390681543854913'
-
-    deleted_self_loops, n = puma_network_post_simplify
-
-    assert n.schedule.stop('5221390681543854913').linkRefId == '5221390681543854913_5221390681543854913'
-    assert n.has_link('5221390681543854913_5221390681543854913')
-    assert n.link('5221390681543854913_5221390681543854913')['from'] == '5221390681543854913'
-    assert n.link('5221390681543854913_5221390681543854913')['to'] == '5221390681543854913'
+def test_simplify_removes_loops_by_default_but_keeps_pt_stop_loops(puma_network):
+    deleted_self_loops = puma_network.simplify()
+    assert deleted_self_loops
+    for stop in puma_network.schedule.stops():
+        assert puma_network.link(stop.linkRefId)['from'] == puma_network.link(stop.linkRefId)['to']
+        assert puma_network.link(stop.linkRefId)['length'] == 1
 
 
-def test_simplified_network_saves_to_correct_dtds(tmpdir, network_dtd, schedule_dtd, puma_network_post_simplify):
-    deleted_self_loops, n = puma_network_post_simplify
-    n.write_to_matsim(tmpdir)
+def test_simplified_network_saves_to_correct_dtds(tmpdir, network_dtd, schedule_dtd, puma_network):
+    try:
+        puma_network.simplify()
+    except Exception as e:
+        raise RuntimeError(f"Error simplifying network: {e}, check other simplification tests")
+    puma_network.write_to_matsim(tmpdir)
 
     generated_network_file_path = os.path.join(tmpdir, 'network.xml')
     xml_obj = lxml.etree.parse(generated_network_file_path)

--- a/tests/test_utils_simplification.py
+++ b/tests/test_utils_simplification.py
@@ -52,14 +52,13 @@ def test_getting_endpoints_with_graph_with_junctions_directed_both_ways(graph_wi
         {node: {'successors': set(g.successors(node)), 'predecessors': set(g.predecessors(node))}
          for node in g.nodes}
     )
-    assert set(endpts) == {1, 2, 5, 6}
+    assert set(endpts) == {1, 2, 5, 6, 11}
 
 
 def test_simplified_paths_with_graph_with_junctions_directed_both_ways(graph_with_junctions_directed_both_ways_and_loop):
     g = graph_with_junctions_directed_both_ways_and_loop
     edge_groups = simplification._get_edge_groups_to_simplify(g)
-    assert_correct_edge_groups(edge_groups, [[2, 11, 11, 2], [2, 3, 4, 5], [2, 22, 33, 44, 55, 5],
-                                             [5, 4, 3, 2], [5, 55, 44, 33, 22, 2]])
+    assert_correct_edge_groups(edge_groups, [[2, 3, 4, 5], [2, 22, 33, 44, 55, 5], [5, 4, 3, 2], [5, 55, 44, 33, 22, 2]])
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Problem

During the simplification process, some links get simplified to loops. In cases of teleported PT, this results in undesirable routes.

For example, given a rail stop sequence: 

```
[A, B, C, D]
```

And the expected, teleported, route is: 

```
[A-A, A-B, B-B, B-C, C-C, C-D, D-D]
```

Right now GeNet oversimplifies the end points resulting in long loops, the route is:

```
[S1, B-B, B-C, C-C, S2]
```

the geometry is retained so they look like lines, but are actually very big loop links, i.e.

```
S1: 
   from node: B 
   to node: B 
```

Not tested, but the likely MATSim consequences are agents not being able to access the service at stops A and D, as MATSim does not use our complex geometry (it's just an additional attribute)

## Fix

Change to defining 'end-points' during simplification - those are the nodes retained in the network during the process. We retain nodes that are self-loops to begin with, thus protecting our PT stops from simplifying. This results in a small increase in retained nodes and fewer links being simplified. 

Difference in the number of links being simplified in the test network:
Before: `6838`
After: `6829`

## Bonus

Now, as default, all links that were simplified to self-loops, will be removed (as they are useless) unless used by PT (we use small self loops as PT stops) or an additional param is given to retain them.

This does not affect the connectivity of the graph.

## Matesto pass

![Screenshot 2022-02-07 at 18 09 22](https://user-images.githubusercontent.com/36536946/152846790-70f30cb1-c1c1-485f-be98-d6575e464b6a.png)
![Screenshot 2022-02-07 at 18 09 29](https://user-images.githubusercontent.com/36536946/152846808-ee67b226-298a-426f-82ff-465e097e5b25.png)
![Screenshot 2022-02-07 at 18 09 35](https://user-images.githubusercontent.com/36536946/152846825-4150d649-902f-4565-bcb2-92e4a8dc65fe.png)

