### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,8 @@ issue.
 
 ## Contributing Code - Pull Request Process
 
+To find beginner-friendly issues you may want to work on, look [here](https://github.com/arup-group/genet/contribute).
+
 1. All new work is done in a branch taken from master, details can be found here:
 [feature branch workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow)
 2. Ensure your work is covered by unit tests to the required percentage level. This script 


### PR DESCRIPTION
Add hyperlink to `/contribute` to help people find beginner-friendly issues.

See the modified section of rendered [here](https://github.com/arup-group/genet/blob/add-contributing-link-to-markdown/CONTRIBUTING.md#contributing-code---pull-request-process)