### PR TITLE
Generalise road pricing type

### DIFF
--- a/genet/__init__.py
+++ b/genet/__init__.py
@@ -1,6 +1,6 @@
 from genet.core import Network  # noqa: F401
 from genet.schedule_elements import Schedule, Service, Route, Stop  # noqa: F401
-from genet.use.road_pricing import Cordon  # noqa: F401
+from genet.use.road_pricing import Toll  # noqa: F401
 from genet.inputs_handler.read import *  # noqa: F401,F403
 from genet.auxiliary_files import AuxiliaryFile  # noqa: F401
 from genet.max_stable_set import MaxStableSet  # noqa: F401

--- a/genet/inputs_handler/read.py
+++ b/genet/inputs_handler/read.py
@@ -345,6 +345,6 @@ def read_matsim_road_pricing(path_to_file):
     """
     TODO: implement
     :param path_to_file: path to MATSim's road_pricing.xml file
-    :return: genet.Cordon.. or other if applicable though not yet implemented (eg distance or area tolling)
+    :return: genet.Toll.. or other if applicable though not yet implemented (eg distance or area tolling)
     """
     pass

--- a/genet/use/road_pricing.py
+++ b/genet/use/road_pricing.py
@@ -9,7 +9,7 @@ from lxml.etree import Element, SubElement, Comment
 from tqdm import tqdm
 
 
-class Cordon:
+class Toll:
     def __init__(self, df_tolls: pd.DataFrame = None):
         if df_tolls is None:
             self.df_tolls = pd.DataFrame(
@@ -33,7 +33,7 @@ class Cordon:
         :param output_dir: path to folder to receive the file
         :return: None
         """
-        self.df_tolls.to_csv(os.path.join(output_dir, 'cordon_road_pricing.csv'), index=False)
+        self.df_tolls.to_csv(os.path.join(output_dir, 'road_pricing.csv'), index=False)
 
     def write_to_xml(self, output_dir):
         """
@@ -47,7 +47,7 @@ class Cordon:
 
 def road_pricing_from_osm(network, attribute_name, osm_csv_path, outpath):
     """
-    Instantiates a Cordon object from OSM csv config and network inputs
+    Instantiates a Toll object from OSM csv config and network inputs
 
     Parse a genet.Network object and find edges whose
     ['attributes'][attribute_name]['text'] is present in a list of OSM way ids
@@ -61,7 +61,7 @@ def road_pricing_from_osm(network, attribute_name, osm_csv_path, outpath):
     """
     osm_df, osm_to_network_dict = extract_network_id_from_osm_csv(network, attribute_name, osm_csv_path, outpath)
     tolls_df = merge_osm_tolls_and_network_snapping(osm_df, osm_to_network_dict)
-    return Cordon(tolls_df)
+    return Toll(tolls_df)
 
 
 def merge_osm_tolls_and_network_snapping(osm_df, osm_to_network_dict):

--- a/genet/use/road_pricing.py
+++ b/genet/use/road_pricing.py
@@ -35,7 +35,8 @@ class Toll:
         """
         self.df_tolls.to_csv(os.path.join(output_dir, filename), index=False)
 
-    def write_to_xml(self, output_dir, filename='roadpricing-file.xml', toll_type='link', toll_scheme_name='simple-toll', toll_description='A simple toll scheme'):
+    def write_to_xml(self, output_dir, filename='roadpricing-file.xml', toll_type='link',
+                     toll_scheme_name='simple-toll', toll_description='A simple toll scheme'):
         """
         Write toll to MATSim xml file
         :param output_dir: path to folder to receive the file

--- a/genet/use/road_pricing.py
+++ b/genet/use/road_pricing.py
@@ -27,22 +27,27 @@ class Toll:
         else:
             self.df_tolls = df_tolls
 
-    def write_to_csv(self, output_dir):
+    def write_to_csv(self, output_dir, filename='road_pricing.csv'):
         """
         Exports all tolls to csv file
         :param output_dir: path to folder to receive the file
         :return: None
         """
-        self.df_tolls.to_csv(os.path.join(output_dir, 'road_pricing.csv'), index=False)
+        self.df_tolls.to_csv(os.path.join(output_dir, filename), index=False)
 
-    def write_to_xml(self, output_dir):
+    def write_to_xml(self, output_dir, filename='roadpricing-file.xml', toll_type='link', toll_scheme_name='simple-toll', toll_description='A simple toll scheme'):
         """
-
+        Write toll to MATSim xml file
         :param output_dir: path to folder to receive the file
+        :param toll_type: default 'link', other supported MATSim toll types: 'distance', 'cordon', 'area',
+            more info: https://www.matsim.org/apidocs/core/0.3.0/org/matsim/roadpricing/package-summary.html
+        :param toll_scheme_name: name to pass to xml file, useful for identifying multiple toll schemes
+        :param toll_description: additional description of the toll to pass to the xml file
         :return: None
         """
-        xml_tree = build_tree(self.df_tolls)
-        write_xml(xml_tree, output_dir)
+        xml_tree = build_tree(
+            self.df_tolls, toll_type=toll_type, toll_scheme_name=toll_scheme_name, toll_description=toll_description)
+        write_xml(xml_tree, output_dir, filename=filename)
 
 
 def road_pricing_from_osm(network, attribute_name, osm_csv_path, outpath):

--- a/tests/test_road_pricing.py
+++ b/tests/test_road_pricing.py
@@ -192,7 +192,7 @@ def test_instantiating_cordon_class_from_osm_inputs(network_object, osm_tolls_df
 
 
 def test_saving_cordon_to_csv_produces_correct_csv(cordon, osm_tolls_df, tmpdir):
-    expected_csv = os.path.join(tmpdir, 'cordon_road_pricing.csv')
+    expected_csv = os.path.join(tmpdir, 'road_pricing.csv')
     assert not os.path.exists(expected_csv)
     cordon.write_to_csv(tmpdir)
     assert os.path.exists(expected_csv)
@@ -227,7 +227,9 @@ def test_building_tree_where_no_links_repeat(tmpdir):
                                             'test_data/road_pricing/osm_to_network_ids_no_link_repeat.json'))
     path_csv = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                              'test_data/road_pricing/osm_tolls_with_network_ids_no_link_overlap.csv'))
-    xml_tree_root = road_pricing.build_tree_from_csv_json(path_csv, path_json)
+    xml_tree_root = road_pricing.build_tree_from_csv_json(
+        path_csv, path_json,
+        toll_type='cordon', toll_scheme_name='cordon-toll', toll_description='A simple cordon toll scheme')
     road_pricing.write_xml(xml_tree_root, tmpdir)
 
     expected_xml = os.path.abspath(os.path.join(os.path.dirname(__file__),
@@ -274,13 +276,13 @@ def test_builds_xml_tree_with_correct_content_from_csv_json(road_pricing_xml_tre
     path_json = 'tests/test_data/road_pricing/osm_to_network_ids.json'
 
     assert road_pricing_xml_tree.tag == 'roadpricing'
-    assert road_pricing_xml_tree.attrib == {'type': 'cordon', 'name': 'cordon-toll'}
+    assert road_pricing_xml_tree.attrib == {'type': 'link', 'name': 'simple-toll'}
     assert len(road_pricing_xml_tree) == 2  # description, links
 
     descs = road_pricing_xml_tree.findall('description')
     assert len(descs) == 1
     assert descs[0].tag == 'description'
-    assert descs[0].text == 'A simple cordon toll scheme'
+    assert descs[0].text == 'A simple toll scheme'
 
     costs = road_pricing_xml_tree.xpath('//cost')
     assert len(costs) == 158

--- a/tests/test_road_pricing.py
+++ b/tests/test_road_pricing.py
@@ -152,7 +152,7 @@ def osm_tolls_df():
 
 @pytest.fixture
 def cordon(osm_tolls_df):
-    return road_pricing.Cordon(osm_tolls_df)
+    return road_pricing.Toll(osm_tolls_df)
 
 
 @pytest.fixture
@@ -188,7 +188,7 @@ def test_instantiating_cordon_class_from_osm_inputs(network_object, osm_tolls_df
         osm_tolls_df,
         check_dtype=False
     )
-    assert isinstance(osm_cordon, road_pricing.Cordon)
+    assert isinstance(osm_cordon, road_pricing.Toll)
 
 
 def test_saving_cordon_to_csv_produces_correct_csv(cordon, osm_tolls_df, tmpdir):

--- a/tests/test_road_pricing.py
+++ b/tests/test_road_pricing.py
@@ -151,7 +151,7 @@ def osm_tolls_df():
 
 
 @pytest.fixture
-def cordon(osm_tolls_df):
+def toll(osm_tolls_df):
     return road_pricing.Toll(osm_tolls_df)
 
 
@@ -176,25 +176,25 @@ def test_merging_osm_and_network_snapping(osm_network_snapping, osm_tolls_df):
     )
 
 
-def test_instantiating_cordon_class_from_osm_inputs(network_object, osm_tolls_df, tmpdir):
-    osm_cordon = road_pricing.road_pricing_from_osm(
+def test_instantiating_toll_class_from_osm_inputs(network_object, osm_tolls_df, tmpdir):
+    osm_toll = road_pricing.road_pricing_from_osm(
         network_object,
         'osm:way:id',
         'tests/test_data/road_pricing/osm_toll_id_ref.csv',
         tmpdir
     )
     assert_frame_equal(
-        osm_cordon.df_tolls.sort_index(axis=1),
+        osm_toll.df_tolls.sort_index(axis=1),
         osm_tolls_df,
         check_dtype=False
     )
-    assert isinstance(osm_cordon, road_pricing.Toll)
+    assert isinstance(osm_toll, road_pricing.Toll)
 
 
-def test_saving_cordon_to_csv_produces_correct_csv(cordon, osm_tolls_df, tmpdir):
+def test_saving_toll_to_csv_produces_correct_csv(toll, osm_tolls_df, tmpdir):
     expected_csv = os.path.join(tmpdir, 'road_pricing.csv')
     assert not os.path.exists(expected_csv)
-    cordon.write_to_csv(tmpdir)
+    toll.write_to_csv(tmpdir)
     assert os.path.exists(expected_csv)
     df_from_csv = pd.read_csv(expected_csv, dtype=str)
     assert_frame_equal(
@@ -204,21 +204,21 @@ def test_saving_cordon_to_csv_produces_correct_csv(cordon, osm_tolls_df, tmpdir)
     )
 
 
-def test_saving_cordon_to_xml_produces_xml_file(cordon, tmpdir):
+def test_saving_toll_to_xml_produces_xml_file(toll, tmpdir):
     # the content of the file is tested elsewhere
     expected_xml = os.path.join(tmpdir, 'roadpricing-file.xml')
     assert not os.path.exists(expected_xml)
-    cordon.write_to_xml(tmpdir)
+    toll.write_to_xml(tmpdir)
     assert os.path.exists(expected_xml)
 
 
-def test_saving_cordon_to_xml_with_missing_toll_ids_produces_xml_file(cordon, tmpdir):
-    cordon.df_tolls = cordon.df_tolls.drop('toll_id', axis=1)
-    assert not 'toll_id' in cordon.df_tolls.columns
+def test_saving_toll_to_xml_with_missing_toll_ids_produces_xml_file(toll, tmpdir):
+    toll.df_tolls = toll.df_tolls.drop('toll_id', axis=1)
+    assert not 'toll_id' in toll.df_tolls.columns
     # the content of the file is tested elsewhere
     expected_xml = os.path.join(tmpdir, 'roadpricing-file.xml')
     assert not os.path.exists(expected_xml)
-    cordon.write_to_xml(tmpdir)
+    toll.write_to_xml(tmpdir)
     assert os.path.exists(expected_xml)
 
 


### PR DESCRIPTION
Gets rid of hard coded Cordon type road pricing. Allows user to specify the toll type, descriptions and allows for change in filenames. Defaults to link type tolling to align with hermes matsim module.