### PR TITLE
Upgrade nbconvert dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ matplotlib==3.2.1
 memory-profiler==0.57.0
 more-itertools==8.3.0
 munch==2.5.0
-nbconvert==6.0.7
+nbconvert==6.4.5
 networkx==2.4
 nose==1.3.7
 numpy>=1.18.4


### PR DESCRIPTION
The [notebooks smoke tests were failing in GitHub Actions builds](https://github.com/arup-group/genet/runs/5734236896?check_suite_focus=true) due to an error from `jinja2`, which is a transitive dependency of the `nbconvert` module we're using. 

Moving to the latest `nbconvert` [fixes this](https://github.com/arup-group/genet/runs/5735692884?check_suite_focus=true):

<img width="1439" alt="Screen Shot 2022-03-29 at 12 21 57" src="https://user-images.githubusercontent.com/250899/160600572-c07f5c0c-f6b4-43a4-9f71-e529baa80936.png">
