### PR TITLE
Reduce Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/__pycache__
+**/.pytest_cache/
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ RUN curl -sL https://deb.nodesource.com/setup_17.x | bash -
 RUN apt-get -y install nodejs && node --version && npm --version &&  \
 rm -rf /var/lib/apt/lists/*
 
-#RUN apt-get install -y coinor-cbc &&  \
-#rm -rf /var/lib/apt/lists/*
-
 RUN /usr/local/bin/python -m pip install --no-cache-dir --compile --upgrade pip
 
 COPY ./scripts .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,22 @@ FROM python:3.7-slim-stretch
 
 RUN apt-get update && \
 apt-get upgrade -y && \
-apt-get -y install gcc git libspatialindex-dev curl &&  \
+apt-get -y install gcc git libspatialindex-dev curl coinor-cbc &&  \
 rm -rf /var/lib/apt/lists/*
 
 RUN curl -sL https://deb.nodesource.com/setup_17.x | bash -
-RUN apt-get -y install nodejs && node --version && npm --version
+RUN apt-get -y install nodejs && node --version && npm --version &&  \
+rm -rf /var/lib/apt/lists/*
 
-RUN apt-get install -y coinor-cbc
+#RUN apt-get install -y coinor-cbc &&  \
+#rm -rf /var/lib/apt/lists/*
 
-RUN /usr/local/bin/python -m pip install --upgrade pip
+RUN /usr/local/bin/python -m pip install --no-cache-dir --compile --upgrade pip
 
 COPY ./scripts .
 COPY . .
 
-RUN pip3 install -e .
+RUN pip3 install --no-cache-dir --compile -e . && pip cache purge
 ENV PYTHONPATH=./scripts:${PYTHONPATH}
 
 ENTRYPOINT ["python3"]


### PR DESCRIPTION
## Before

```bash
REPOSITORY               TAG        IMAGE ID       CREATED             SIZE
genet-local-master       latest     3e95afde36e9   30 seconds ago      1.75GB
```

## After
```bash
REPOSITORY            TAG        IMAGE ID       CREATED             SIZE
genet-local           latest     61c9395a63bf   26 minutes ago      1.46GB
```
Still pretty chonky, even after reclaiming 300 megs. Questions @KasiaKoz:
- Do we still need that Node installation? I think it was for something to do with Kepler, right?
- `notebooks/7. Visualising Network.ipynb` is over 40 MB in size - is that expected? Seems outrageously big for a notebook.

## Validating the image
I connected to the container and ran both the unit tests and the notebook smoke tests. The smoke tests all passed, but one unit test failed. However, when I ran the unit tests in the container created from the image in `master`, I saw the same failure, so this does not seem to have been caused by my changes.

<img width="621" alt="Screen Shot 2022-04-06 at 02 23 04" src="https://user-images.githubusercontent.com/250899/161878294-8772cca5-9bb6-481f-8841-bb8fbb7176af.png">
<img width="1435" alt="Screen Shot 2022-04-06 at 02 16 25" src="https://user-images.githubusercontent.com/250899/161878306-17564fe0-c64f-4d3d-9bf8-e40c5a941e17.png">
