### PR TITLE
Loosen version constraints for various pytest-related dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ decorator==4.4.2
 descartes==1.1.0
 dictdiffer==0.8.1
 docutils==0.15.2
-Fiona==1.8.20
 flake8>=3.8.4
 future==0.18.2
 geopandas==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ decorator==4.4.2
 descartes==1.1.0
 dictdiffer==0.8.1
 docutils==0.15.2
+Fiona==1.8.20
 flake8>=3.8.4
 future==0.18.2
 geopandas==0.9.0
@@ -56,10 +57,10 @@ Pyomo==5.7.3
 Pygments==2.7.4
 pyparsing==2.4.7
 pyproj>=3.1.0
-pytest==6.2.5
-pytest-cov==2.12.1
-pytest-mock==3.1.0
-pytest-xdist==2.3.0
+pytest>=6.0.0
+pytest-cov>=2.0.0
+pytest-mock>=3.0.0
+pytest-xdist>=2.0.0
 python-dateutil==2.8.1
 pytz==2020.1
 PyUtilib>=5.8.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if os.path.isfile(requirementPath):
 
 setup(
     name="genet",
-    version="0.0.1",
+    version="1.0.1",
     author="Kasia Kozlowska",
     author_email="",
     description="MATSim network scenario generator",


### PR DESCRIPTION
When trying to install `scop`:
<img width="1401" alt="Screen Shot 2022-04-08 at 13 27 46" src="https://user-images.githubusercontent.com/250899/162435544-f26e4f83-de9d-485b-a3a2-fd03f6f5469b.png">

This is a spurious version clash - it is almost certain that both apps/libs will work with either version of `pytest-cov`.

We could decide to loosen the constraints for more than just these libraries, of course, but for now these will hopefully at least fix Scop's problem. Opinions welcome.

I may create a similar PR for MC that is much more flexible on the test dependencies, but still specific about non-test dependency.