### PR TITLE
Add a minimal daily scheduled CI build

### DIFF
--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -60,7 +60,7 @@ jobs:
       env:
         SLACK_COLOR: '#FF0000'
         SLACK_LINK_NAMES: true
-        SLACK_MESSAGE: @here ${{ github.repository }} Daily scheduled CI Build ${{ github.run_number }} has failed
+        SLACK_MESSAGE: '<!here> ${{ github.repository }} Daily scheduled CI Build ${{ github.run_number }} has failed'
         SLACK_TITLE: Daily Scheduled CI Build Failure!
         SLACK_CHANNEL: city-modelling-feeds
         SLACK_USERNAME: GitHub Build Bot

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -48,7 +48,7 @@ jobs:
       uses: rtCamp/action-slack-notify@v2.0.0
       env:
         SLACK_MESSAGE: ${{ github.repository }} Daily scheduled CI Build ${{ github.run_number }} has succeeded
-        SLACK_TITLE: Build Success
+        SLACK_TITLE: Daily Scheduled CI Build Success
         SLACK_CHANNEL: city-modelling-feeds
         SLACK_USERNAME: GitHub Build Bot
         SLACK_ICON: https://slack-files2.s3-us-west-2.amazonaws.com/avatars/2017-12-19/288981919427_f45f04edd92902a96859_512.png
@@ -59,8 +59,9 @@ jobs:
       uses: rtCamp/action-slack-notify@v2.0.0
       env:
         SLACK_COLOR: '#FF0000'
-        SLACK_MESSAGE: ${{ github.repository }} Daily scheduled CI Build ${{ github.run_number }} has failed
-        SLACK_TITLE: Build Failure!
+        SLACK_LINK_NAMES: true
+        SLACK_MESSAGE: @here ${{ github.repository }} Daily scheduled CI Build ${{ github.run_number }} has failed
+        SLACK_TITLE: Daily Scheduled CI Build Failure!
         SLACK_CHANNEL: city-modelling-feeds
         SLACK_USERNAME: GitHub Build Bot
         SLACK_ICON: https://slack-files2.s3-us-west-2.amazonaws.com/avatars/2017-12-19/288981919427_f45f04edd92902a96859_512.png

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -1,0 +1,67 @@
+name: Daily GeNet CI Build
+
+on:
+  schedule:
+    - cron: '37 14 * * 1-5'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        export ACCEPT_EULA=Y
+        sudo apt-get update
+        python -m pip install --upgrade pip
+        sudo apt-get install -y python3-pip libgdal-dev locales
+        sudo apt-get install -y libspatialindex-dev
+        sudo apt-get install -y coinor-cbc
+        export CPLUS_INCLUDE_PATH=/usr/include/gdal
+        export C_INCLUDE_PATH=/usr/include/gdal
+        sudo apt-get install ca-certificates
+        export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+        pip install GDAL==3.0.2
+        pip install -e .
+
+    - name: Run tests
+      run: |
+        export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+        ./bash_scripts/code-coverage.sh
+
+    - name: Send build success notification
+      if: success()
+      uses: rtCamp/action-slack-notify@v2.0.0
+      env:
+        SLACK_MESSAGE: ${{ github.repository }} Daily scheduled CI Build ${{ github.run_number }} has succeeded
+        SLACK_TITLE: Build Success
+        SLACK_CHANNEL: city-modelling-feeds
+        SLACK_USERNAME: GitHub Build Bot
+        SLACK_ICON: https://slack-files2.s3-us-west-2.amazonaws.com/avatars/2017-12-19/288981919427_f45f04edd92902a96859_512.png
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    - name: Send build failure notification
+      if: failure()
+      uses: rtCamp/action-slack-notify@v2.0.0
+      env:
+        SLACK_COLOR: '#FF0000'
+        SLACK_MESSAGE: ${{ github.repository }} Daily scheduled CI Build ${{ github.run_number }} has failed
+        SLACK_TITLE: Build Failure!
+        SLACK_CHANNEL: city-modelling-feeds
+        SLACK_USERNAME: GitHub Build Bot
+        SLACK_ICON: https://slack-files2.s3-us-west-2.amazonaws.com/avatars/2017-12-19/288981919427_f45f04edd92902a96859_512.png
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
A minimal daily scheduled CI build that runs the unit tests in an attempt to uncover any problems caused by having loosened the version constraints on some of our dependencies.

See https://arupdigital.atlassian.net/browse/LAB-1639.

Note that, for security reasons, new Actions workflows do not run until they have been created in the default branch, so we won't see this scheduled build start to run until after this PR has been merged.