### PR TITLE
Improve notebooks smoke test report

### DIFF
--- a/notebooks/notebook_smoke_tests.py
+++ b/notebooks/notebook_smoke_tests.py
@@ -66,13 +66,13 @@ def install_jupyter_kernel(kernel_name):
 
 def execute_notebook(notebook_path):
     print("Executing notebook '{}{}{}'...".format(Fore.YELLOW, notebook_path, Style.RESET_ALL))
-    kernel_install_cmd = [
+    cmd = [
         'jupyter', 'nbconvert',
         '--to', 'notebook',
         '--execute', '"{}"'.format(notebook_path),
         '--output-dir=/tmp'
     ]
-    return run_shell_command(kernel_install_cmd)
+    return run_shell_command(cmd)
 
 
 def run_shell_command(shell_cmd):
@@ -128,6 +128,7 @@ if __name__ == '__main__':
     command_args = parse_args(sys.argv[1:])
     if command_args['notebook']:
         notebooks = command_args['notebook']
+        notebooks.sort()
         print("Executing notebooks files {}{}{}".format(Fore.YELLOW,
                                                         notebooks,
                                                         Style.RESET_ALL))

--- a/notebooks/notebook_smoke_tests.py
+++ b/notebooks/notebook_smoke_tests.py
@@ -16,12 +16,16 @@ def parse_args(cmd_args):
     arg_parser = argparse.ArgumentParser(description='Smoke test a set of Jupyter notebook files')
     arg_parser.add_argument('-d',
                             '--notebook-directory',
-                            help='the path to the directory containing the notebooks to test',
-                            required=True)
+                            help='the path to the directory containing the notebooks to test')
     arg_parser.add_argument('-k',
                             '--kernel-name',
-                            help='the name of the Jupyter kernel to install',
+                            help='the name of an iPython kernel to install',
                             required=True)
+    arg_parser.add_argument('-n',
+                            '--notebook',
+                            action='append',
+                            help='an iPython notebook to execute - takes precedence over '
+                                 '--notebook-directory if both are set')
     return vars(arg_parser.parse_args(cmd_args))
 
 
@@ -100,16 +104,22 @@ if __name__ == '__main__':
     print_banner()
     start = datetime.now()
     command_args = parse_args(sys.argv[1:])
-    print("Smoke testing Jupyter notebooks in {}'{}'{} directory".format(Fore.YELLOW,
-                                                                         command_args['notebook_directory'],
-                                                                         Style.RESET_ALL))
-    notebooks = find_notebooks(command_args['notebook_directory'])
-    print("Found {}{}{} notebooks files in {}{}{}".format(Fore.YELLOW,
-                                                          len(notebooks),
-                                                          Style.RESET_ALL,
-                                                          Fore.YELLOW,
-                                                          command_args['notebook_directory'],
-                                                          Style.RESET_ALL))
+    if command_args['notebook']:
+        notebooks = command_args['notebook']
+        print("Executing notebooks files {}{}{}".format(Fore.YELLOW,
+                                                        notebooks,
+                                                        Style.RESET_ALL))
+    elif command_args['notebook_directory']:
+        print("Smoke testing Jupyter notebooks in {}'{}'{} directory".format(Fore.YELLOW,
+                                                                             command_args['notebook_directory'],
+                                                                             Style.RESET_ALL))
+        notebooks = find_notebooks(command_args['notebook_directory'])
+        print("Found {}{}{} notebooks files in {}{}{}".format(Fore.YELLOW,
+                                                              len(notebooks),
+                                                              Style.RESET_ALL,
+                                                              Fore.YELLOW,
+                                                              command_args['notebook_directory'],
+                                                              Style.RESET_ALL))
     if not notebooks:
         print("No notebooks to test - our work here is done. Double check the {}{}{} directory if this seems wrong."
               .format(Fore.YELLOW, command_args['notebook_directory'], Style.RESET_ALL))

--- a/notebooks/notebook_smoke_tests.py
+++ b/notebooks/notebook_smoke_tests.py
@@ -2,16 +2,12 @@ import argparse
 import glob
 import subprocess
 import sys
-
 from datetime import datetime
 from pprint import pprint
 
 from colorama import Fore, Style
 from rich.console import Console
 from rich.table import Table
-
-TICK_SYMBOL = u'\u2713'
-CROSS_SYMBOL = u'\u274C'
 
 
 def parse_args(cmd_args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,6 +67,7 @@ PyYAML==5.4
 pyzmq==19.0.1
 requests==2.26.0
 requests-futures==1.0.0
+rich==12.5.1
 rioxarray==0.9.1
 Rtree==0.9.4
 s2sphere==0.2.5


### PR DESCRIPTION
## Before

#### Running locally
<img width="1440" alt="Screen Shot 2022-07-14 at 20 19 03" src="https://user-images.githubusercontent.com/250899/179065759-e47b5414-c649-4019-befe-c720df2365c4.png">

#### Running in GitHub Actions
<img width="635" alt="Screen Shot 2022-07-14 at 19 49 44" src="https://user-images.githubusercontent.com/250899/179060373-9d30a2e9-282c-4b77-885b-48733f946d38.png">


## After

#### Running locally
<img width="1440" alt="Screen Shot 2022-07-14 at 20 12 35" src="https://user-images.githubusercontent.com/250899/179064607-d77339af-3869-46a3-b2dd-1bb434dd8c15.png">

#### Running in GitHub Actions
<img width="707" alt="Screen Shot 2022-07-14 at 20 04 18" src="https://user-images.githubusercontent.com/250899/179063124-7c919c4e-db54-4ba5-9ec3-ccfb02fcf335.png">


## Additional Functionality
You can now optionally pass one or more notebook paths as params to the python script, where before you could pass only a directory from which the list of notebooks would be discovered.

This was mostly just to give me a faster feedback loop than running all the notebooks while working on these changes, but could still be generally useful in situations where you're making changes to one or two notebooks and want the same sort of fast feedback. For example:

```bash
python notebooks/notebook_smoke_tests.py -k genet \
-n 'notebooks/1. Intro.ipynb' \
-n 'notebooks/2.4. Reading CSV data.ipynb' \
-n 'notebooks/3.3. Writing GTFS data.ipynb' \
-n 'notebooks/4.3. Using Network - Routing.ipynb' \
-n 'notebooks/4.4. Using Network - Auxiliary Files referencing Network IDs.ipynb'
```

<img width="924" alt="Screen Shot 2022-07-14 at 19 56 58" src="https://user-images.githubusercontent.com/250899/179061616-d12f5e2e-ec42-47d6-9e3c-6a407a317a4e.png">
<img width="1440" alt="Screen Shot 2022-07-14 at 21 17 27" src="https://user-images.githubusercontent.com/250899/179075735-2c3222f3-d9db-450c-b190-28e9443c68e1.png">


**NB:** The notebooks (and unit tests) that rely on the solver fail on my machine because I don't have the underlying native solver installed. I get `ApplicationError: No executable found for solver 'cbc'`. I don't consider it a priority to address that. It turned out that those failures were quite handy for me while I was making these changes, because I wanted to see a mixture of passing and failing notebooks in the summary.