### PR TITLE
Validation zhuzh-up: PT speed computation

### DIFF
--- a/genet/output/geojson.py
+++ b/genet/output/geojson.py
@@ -69,7 +69,7 @@ def save_geodataframe(gdf, filename, output_dir, include_shp_files=False):
 def generate_standard_outputs_for_schedule(schedule, output_dir, gtfs_day='19700101', include_shp_files=False):
     logging.info('Generating geojson standard outputs for schedule')
     schedule_links = schedule.to_geodataframe()['links'].to_crs("epsg:4326")
-    df = schedule.trips_with_stops_and_speed(gtfs_day=gtfs_day)
+    df = schedule.trips_with_stops_to_dataframe(gtfs_day=gtfs_day)
     df_all_modes_vph = None
 
     vph_dir = os.path.join(output_dir, 'vehicles_per_hour')
@@ -125,16 +125,16 @@ def generate_standard_outputs_for_schedule(schedule, output_dir, gtfs_day='19700
         )
 
     logging.info('Generating spatial speed outputs')
+    speed_dir = os.path.join(output_dir, 'speed')
     speeds_gdf = gpd.GeoDataFrame(
-        pd.merge(df, schedule_links[['u', 'v', 'geometry']],
+        pd.merge(schedule.speed_dataframe(), schedule_links[['u', 'v', 'geometry']],
                  left_on=['from_stop', 'to_stop'], right_on=['u', 'v']),
         crs=schedule_links.crs)
-    speeds_gdf = speeds_gdf[
-        ['service_id', 'route_id', 'mode', 'from_stop', 'to_stop', 'speed', 'geometry']].drop_duplicates()
+    speeds_gdf = speeds_gdf[['service_id', 'route_id', 'mode', 'from_stop', 'to_stop', 'speed', 'geometry']]
     save_geodataframe(
         speeds_gdf,
         filename='pt_speeds',
-        output_dir=output_dir,
+        output_dir=speed_dir,
         include_shp_files=include_shp_files
     )
 

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -260,20 +260,22 @@ class ScheduleElement:
         return None
 
     @abstractmethod
-    def trips_with_stops_to_dataframe(self) -> pd.DataFrame:
+    def trips_with_stops_to_dataframe(self, gtfs_day='19700101') -> pd.DataFrame:
         pass
 
-    def trips_with_stops_and_speed(self, network_factor=1.3) -> pd.DataFrame:
+    def trips_with_stops_and_speed(self, gtfs_day='19700101', network_factor=1.3) -> pd.DataFrame:
         """
         DataFrame: trips_with_stops_to_dataframe, but with speed in metres/second between each of the stops.
         Note well:
          - The unit of metres is not guaranteed - this assumes the object is in local metre-based projection.
          - It does not consider network routes, uses 1.3 network factor as default
+        :param gtfs_day: optional, used to set the day represented by the network in the datetime objects in resulting
+            dataframe.
         :param network_factor: Does not consider network routes, network factor (default 1.3) is applied to Euclidean
             distance.
         :return:
         """
-        df = self.trips_with_stops_to_dataframe()
+        df = self.trips_with_stops_to_dataframe(gtfs_day)
         df['distance'] = df.apply(
             lambda row: spatial.distance_between_s2cellids(
                 self._graph.nodes[row['from_stop']]['s2_id'],

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -263,9 +263,11 @@ class ScheduleElement:
     def service_attribute_data(self, keys: Union[list, str], index_name: str = None):
         pass
 
+    @abstractmethod
     def route_attribute_data(self, keys: Union[list, str], index_name: str = None):
         pass
 
+    @abstractmethod
     def stop_attribute_data(self, keys: Union[list, str], index_name: str = None):
         pass
 

--- a/genet/validate/schedule.py
+++ b/genet/validate/schedule.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 
 def generate_validation_report(schedule):
@@ -102,6 +103,17 @@ def generate_validation_report(schedule):
                         f"The following Services are affected: {report['schedule_level']['headways']['services']}")
     else:
         report['schedule_level']['headways']['has_zero_min_headways'] = False
+
+    logging.info('Computing speeds')
+    df_speeds = schedule.trips_with_stops_and_speed()
+    logging.info('Checking speeds for prohibitive values 0 and infinity. You should verify speed values separately')
+    report['schedule_level']['speeds'] = {}
+    for val in [0, math.inf]:
+        val_df = df_speeds[df_speeds['speed'] == val]
+        if not val_df.empty:
+            report['schedule_level']['speeds'][str(val)] = {
+                'routes': list(val_df['route_id'].unique())
+            }
 
     if not is_valid_schedule:
         logging.warning('This schedule is not valid')

--- a/genet/validate/schedule.py
+++ b/genet/validate/schedule.py
@@ -105,13 +105,13 @@ def generate_validation_report(schedule):
         report['schedule_level']['headways']['has_zero_min_headways'] = False
 
     logging.info('Computing speeds')
-    df_speeds = schedule.trips_with_stops_and_speed()
+    df_speeds = schedule.speed_dataframe()
     logging.info('Checking speeds for prohibitive values 0 and infinity. You should verify speed values separately')
     report['schedule_level']['speeds'] = {}
     for val in [0, math.inf]:
         val_df = df_speeds[df_speeds['speed'] == val]
         if not val_df.empty:
-            report['schedule_level']['speeds'][str(val)] = {
+            report['schedule_level']['speeds'][f'{val}_m/s'] = {
                 'routes': list(val_df['route_id'].unique())
             }
 

--- a/tests/test_core_components_route.py
+++ b/tests/test_core_components_route.py
@@ -5,6 +5,7 @@ from pandas.testing import assert_frame_equal
 from genet.schedule_elements import Route, Stop
 from genet.utils import plot
 from tests.fixtures import stop_epsg_27700, assert_semantically_equal, assert_logging_warning_caught_with_message_containing
+from genet.exceptions import ServiceIndexError
 
 
 @pytest.fixture()
@@ -453,3 +454,34 @@ def test_generating_trips_dataframe(route):
 
 def test_vehicles(route):
     assert route.vehicles() == {'veh_1_bus', 'veh_2_bus'}
+
+
+def test_service_attribute_data_under_keys_throws_error_from_route_object(route, pytest):
+    with pytest.raises(ServiceIndexError) as error_info:
+        df = route.service_attribute_data(keys=['name'])
+
+
+def test_route_attribute_data_under_key(route):
+    df = route.route_attribute_data(keys='route_short_name').sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'route_short_name': {'1': 'name'}}
+    ))
+
+
+def test_route_attribute_data_under_keys(route):
+    df = route.route_attribute_data(keys=['route_short_name', 'mode']).sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'route_short_name': {'1': 'name'}, 'mode': {'1': 'bus'}}
+    ))
+
+
+def test_stop_attribute_data_under_key(route):
+    df = route.stop_attribute_data(keys='x').sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'x': {'1': 4.0, '2': 1.0, '3': 3.0, '4': 7.0}}))
+
+
+def test_stop_attribute_data_under_keys(route):
+    df = route.stop_attribute_data(keys=['x', 'y']).sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'x': {'1': 4.0, '2': 1.0, '3': 3.0, '4': 7.0}, 'y': {'1': 2.0, '2': 2.0, '3': 3.0, '4': 5.0}}))

--- a/tests/test_core_components_route.py
+++ b/tests/test_core_components_route.py
@@ -456,7 +456,7 @@ def test_vehicles(route):
     assert route.vehicles() == {'veh_1_bus', 'veh_2_bus'}
 
 
-def test_service_attribute_data_under_keys_throws_error_from_route_object(route, pytest):
+def test_service_attribute_data_under_keys_throws_error_from_route_object(route):
     with pytest.raises(ServiceIndexError) as error_info:
         df = route.service_attribute_data(keys=['name'])
 

--- a/tests/test_core_components_service.py
+++ b/tests/test_core_components_service.py
@@ -447,3 +447,44 @@ def test_generating_trips_dataframe(service):
 
 def test_vehicles(service):
     assert service.vehicles() == {'veh_1_bus', 'veh_2_bus', 'veh_3_bus', 'veh_4_bus'}
+
+
+def test_service_attribute_data_under_key(service):
+    df = service.service_attribute_data(keys='name').sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'name': {'service': 'name'}}
+    ))
+
+
+def test_service_attribute_data_under_keys(service):
+    df = service.service_attribute_data(keys=['name', 'id']).sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'name': {'service': 'name'}, 'id': {'service': 'service'}}
+    ))
+
+
+def test_route_attribute_data_under_key(service):
+    df = service.route_attribute_data(keys='route_short_name').sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'route_short_name': {'1': 'name', '2': 'name_2'}}
+    ))
+
+
+def test_route_attribute_data_under_keys(service):
+    df = service.route_attribute_data(keys=['route_short_name', 'mode']).sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'route_short_name': {'1': 'name', '2': 'name_2'}, 'mode': {'1': 'bus', '2': 'bus'}}
+    ))
+
+
+def test_stop_attribute_data_under_key(service):
+    df = service.stop_attribute_data(keys='x').sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'x': {'1': 4.0, '2': 1.0, '3': 3.0, '4': 7.0, '5': 4.0, '6': 1.0, '7': 3.0, '8': 7.0}}))
+
+
+def test_stop_attribute_data_under_keys(service):
+    df = service.stop_attribute_data(keys=['x', 'y']).sort_index()
+    assert_frame_equal(df, DataFrame(
+        {'x': {'1': 4.0, '2': 1.0, '3': 3.0, '4': 7.0, '5': 4.0, '6': 1.0, '7': 3.0, '8': 7.0},
+         'y': {'1': 2.0, '2': 2.0, '3': 3.0, '4': 5.0, '5': 2.0, '6': 2.0, '7': 3.0, '8': 5.0}}))

--- a/tests/test_core_schedule.py
+++ b/tests/test_core_schedule.py
@@ -2014,13 +2014,10 @@ def schedule_for_speed_testing():
         'network_factor': 1.3,
         'stops_distance': 10 / (1.3),
         'expected_trips_with_stops_and_speed_df': DataFrame(
-            {'departure_time': {0: Timestamp('1970-01-01 05:40:00'), 1: Timestamp('1970-01-01 05:40:01')},
-             'arrival_time': {0: Timestamp('1970-01-01 05:40:01'), 1: Timestamp('1970-01-01 05:40:03')},
-             'mode': {0: 'bus', 1: 'bus'}, 'service_id': {0: 'service', 1: 'service'},
+            {'mode': {0: 'bus', 1: 'bus'}, 'service_id': {0: 'service', 1: 'service'},
              'route_name': {0: 'route', 1: 'route'}, 'route_id': {0: 'service_0', 1: 'service_0'},
              'to_stop': {0: '1', 1: '2'}, 'from_stop_name': {0: '', 1: ''}, 'from_stop': {0: '0', 1: '1'},
-             'service_name': {0: 'route', 1: 'route'}, 'to_stop_name': {0: '', 1: ''}, 'trip_id': {0: 't1', 1: 't1'},
-             'vehicle_id': {0: 'veh_1_bus', 1: 'veh_1_bus'},
+             'service_name': {0: 'route', 1: 'route'}, 'to_stop_name': {0: '', 1: ''},
              'speed': {0: 10.0, 1: 5.0}}
         ),
         'expected_route_speeds': {'service_0': 7.5},
@@ -2046,17 +2043,14 @@ def schedule_for_testing_0_speed_case():
         'network_factor': 1.3,
         'stops_distance': 0,
         'expected_trips_with_stops_and_speed_df': DataFrame(
-            {'departure_time': {0: Timestamp('1970-01-01 05:40:00')},
-             'arrival_time': {0: Timestamp('1970-01-01 05:40:01')},
-             'mode': {0: 'bus'}, 'service_id': {0: 'service'},
+            {'mode': {0: 'bus'}, 'service_id': {0: 'service'},
              'route_name': {0: 'route'}, 'route_id': {0: 'service_0'},
              'to_stop': {0: '1'}, 'from_stop_name': {0: ''}, 'from_stop': {0: '0'},
-             'service_name': {0: 'route'}, 'to_stop_name': {0: ''}, 'trip_id': {0: 't1'},
-             'vehicle_id': {0: 'veh_1_bus'},
+             'service_name': {0: 'route'}, 'to_stop_name': {0: ''},
              'speed': {0: 0.0}}
         ),
         'expected_route_speeds': {'service_0': 0.0},
-        'expected_speed_report': {'0': {'routes': ['service_0']}}
+        'expected_speed_report': {'0_m/s': {'routes': ['service_0']}}
     }
 
 
@@ -2078,17 +2072,14 @@ def schedule_for_testing_inf_speed_case():
         'network_factor': 1.3,
         'stops_distance': 20,
         'expected_trips_with_stops_and_speed_df': DataFrame(
-            {'departure_time': {0: Timestamp('1970-01-01 05:40:00')},
-             'arrival_time': {0: Timestamp('1970-01-01 05:40:00')},
-             'mode': {0: 'bus'}, 'service_id': {0: 'service'},
+            {'mode': {0: 'bus'}, 'service_id': {0: 'service'},
              'route_name': {0: 'route'}, 'route_id': {0: 'service_0'},
              'to_stop': {0: '1'}, 'from_stop_name': {0: ''}, 'from_stop': {0: '0'},
-             'service_name': {0: 'route'}, 'to_stop_name': {0: ''}, 'trip_id': {0: 't1'},
-             'vehicle_id': {0: 'veh_1_bus'},
+             'service_name': {0: 'route'}, 'to_stop_name': {0: ''},
              'speed': {0: math.inf}}
         ),
         'expected_route_speeds': {'service_0': math.inf},
-        'expected_speed_report': {'inf': {'routes': ['service_0']}}
+        'expected_speed_report': {'inf_m/s': {'routes': ['service_0']}}
     }
 
 @pytest.fixture()
@@ -2107,7 +2098,7 @@ def test_speed_calculation_for_schedule(schedule_case, schedule_cases_for_speed_
     mocker.patch.object(spatial, 'distance_between_s2cellids',
                         return_value=schedule_fixture['stops_distance'])
     assert_frame_equal(
-        schedule_fixture['schedule'].trips_with_stops_and_speed(network_factor=network_factor).sort_index(
+        schedule_fixture['schedule'].speed_dataframe(network_factor=network_factor).sort_index(
             axis=1),
         schedule_fixture['expected_trips_with_stops_and_speed_df'].sort_index(axis=1)
     )

--- a/tests/test_core_schedule.py
+++ b/tests/test_core_schedule.py
@@ -2036,7 +2036,7 @@ def test_speed_calculation_for_schedule(schedule_for_speed_testing, mocker):
     )
 
 
-def test_speed_for_each_route_calculation_for_schedule(schedule_for_speed_testing, mocker):
+def test_average_speed_calculation_for_each_route_in_schedule(schedule_for_speed_testing, mocker):
     network_factor = schedule_for_speed_testing['network_factor']
     mocker.patch.object(spatial, 'distance_between_s2cellids',
                         return_value=schedule_for_speed_testing['stops_distance'])

--- a/tests/test_output_geojson.py
+++ b/tests/test_output_geojson.py
@@ -210,8 +210,10 @@ def test_generating_standard_outputs(network, tmpdir):
                                                                  'trips_per_day_per_service.csv',
                                                                  'trips_per_day_per_route.csv',
                                                                  'trips_per_day_per_route_aggregated_per_stop_id_pair.csv',
-                                                                 'trips_per_day_per_route_aggregated_per_stop_name_pair.csv'
+                                                                 'trips_per_day_per_route_aggregated_per_stop_name_pair.csv',
+                                                                 'speed'
                                                                  }
+    assert set(os.listdir(os.path.join(tmpdir, 'schedule', 'speed'))) == {'pt_speeds.geojson', 'shp_files'}
     assert set(os.listdir(os.path.join(tmpdir, 'schedule', 'vehicles_per_hour'))) == {'vph_per_service.csv',
                                                                                       'vehicles_per_hour_all_modes.geojson',
                                                                                       'vph_per_stop_departing_from.csv',

--- a/tests/test_validate_schedule.py
+++ b/tests/test_validate_schedule.py
@@ -37,7 +37,7 @@ def correct_schedule():
 def test_generate_validation_report_for_correct_schedule(correct_schedule):
     correct_report = {
         'schedule_level': {'is_valid_schedule': True, 'invalid_stages': [], 'has_valid_services': True,
-                           'invalid_services': [], 'headways': {'has_zero_min_headways': False}},
+                           'invalid_services': [], 'headways': {'has_zero_min_headways': False}, 'speeds': {}},
         'service_level': {
             'service': {'is_valid_service': True, 'invalid_stages': [],
                         'has_valid_routes': True, 'invalid_routes': []}},
@@ -63,7 +63,7 @@ def test_generate_validation_report_for_incorrect_schedule(test_schedule):
     correct_report = {
         'schedule_level': {'is_valid_schedule': False, 'invalid_stages': ['not_has_valid_services'],
                            'has_valid_services': False, 'invalid_services': ['service'],
-                           'headways': {'has_zero_min_headways': False}},
+                           'headways': {'has_zero_min_headways': False}, 'speeds': {'0_m/s': {'routes': ['service_0', 'service_1']}}},
         'service_level': {'service': {'is_valid_service': False,
                         'invalid_stages': ['not_has_valid_routes'],
                         'has_valid_routes': False, 'invalid_routes': ['service_0', 'service_1']}},
@@ -117,42 +117,16 @@ def schedule_with_incomplete_vehicle_definition():
 
 
 def test_generate_validation_report_with_schedule_incomplete_vehicle_definitions(schedule_with_incomplete_vehicle_definition):
-    correct_report = {'route_level':
-                          {'service':
-                               {'service_0': {'invalid_stages': ['not_has_correctly_ordered_route', 'has_self_loops'],
-                                              'is_valid_route': False,
-                                              'headway_stats': {'mean_headway_mins': float('nan'),
-                                                                'std_headway_mins': float('nan'),
-                                                                'max_headway_mins': float('nan'),
-                                                                'min_headway_mins': float('nan')}
-                                              },
-                                'service_1': {'invalid_stages': ['not_has_correctly_ordered_route', 'has_self_loops'],
-                                              'is_valid_route': False,
-                                              'headway_stats': {'mean_headway_mins': float('nan'),
-                                                                'std_headway_mins': float('nan'),
-                                                                'max_headway_mins': float('nan'),
-                                                                'min_headway_mins': float('nan')}
-                                              }}},
-         'schedule_level': {'has_valid_services': False,
-                            'invalid_services': ['service'],
-                            'invalid_stages': ['not_has_valid_services', 'not_has_valid_vehicle_definitions'],
-                            'is_valid_schedule': False,
-                            'headways': {'has_zero_min_headways': False}
-                            },
-         'service_level': {'service': {'has_valid_routes': False,
-                                       'invalid_routes': ['service_0', 'service_1'],
-                                       'invalid_stages': ['not_has_valid_routes'],
-                                       'is_valid_service': False}},
-         'vehicle_level': {'vehicle_definitions_valid': False,
+    correct_vehicle_report = {'vehicle_definitions_valid': False,
                            'vehicle_definitions_validity_components': {
                                'missing_vehicles': {'missing_vehicles_types': {'bus'},
                                                     'vehicles_affected': {'veh_1_bus': {'type': 'bus'},
                                                                           'veh_2_bus': {'type': 'bus'}}},
                                'multiple_use_vehicles': {},
-                               'unused_vehicles': set()}}}
+                               'unused_vehicles': set()}}
 
     report = schedule_validation.generate_validation_report(schedule_with_incomplete_vehicle_definition)
-    assert_semantically_equal(report, correct_report)
+    assert_semantically_equal(report['vehicle_level'], correct_vehicle_report)
 
 
 


### PR DESCRIPTION
Resolves: https://github.com/arup-group/genet/issues/145 - Add speed computation and checks

- Adds a method to get a DataFrame with routes : speed (where the speeds are between stop pairs: crowfly distance times a network factor that defaults to 1.3)
- Adds a method to get average speed for each route (average between stop-to-stop pairs)
- Adds checks for 0 and infinity values of speeds in the validation report
- Adds a geojson/shp file output with stop-to-stop speeds in standard outputs, example pic below:
![Screenshot 2022-09-15 at 09 17 49](https://user-images.githubusercontent.com/36536946/190456843-d554cfdc-5be9-4119-ac2a-6f3304af9eaa.png)

Nb. Part of a wider validation upgrade series. I'm leaving updating the notebook: [6.1. Validating Network: MATSim Specific](https://github.com/arup-group/genet/blob/main/notebooks/6.1.%20Validating%20Network:%20MATSim%20Specific.ipynb) to last in the series.