### PR TITLE
Use multiprocessing in the notebooks smoketest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ scripts/secrets-mgr-exploration.py
 example_data/pt2matsim_network/genet_output/*
 genet_output/*
 example_data/output_*/*
+example_data/api_requests_send.json


### PR DESCRIPTION
Exactly the same as [LAB-1905](https://arupdigital.atlassian.net/browse/LAB-1905).

### Before

Nearly 4.5 minutes running locally
<img width="836" alt="Screen Shot 2022-10-12 at 22 22 47" src="https://user-images.githubusercontent.com/250899/195451761-e7f36577-9fef-4494-8657-be956f7c158f.png">

Around 4 minutes running in the CI build
<img width="1396" alt="Screen Shot 2022-10-12 at 22 36 00" src="https://user-images.githubusercontent.com/250899/195452546-1c466074-c6cc-41e0-bdc1-4f4c13127965.png">


### After

Around 1m 15s running locally
<img width="837" alt="Screen Shot 2022-10-12 at 22 27 09" src="https://user-images.githubusercontent.com/250899/195451864-19d6aa64-acd6-4859-9072-4e2a8953d659.png">

Around 2 minutes running in the CI build
<img width="1382" alt="Screen Shot 2022-10-12 at 22 42 52" src="https://user-images.githubusercontent.com/250899/195453630-11231691-310f-4ce4-8ac9-0bc478bbdfbf.png">


### Question

The notebooks now run in parallel and finish in a non-deterministic order. They appear in the summary table printed to console at the end of the tests in the (non-deterministic) order that they finished .  _Technically_ it was always the case that they appeared in order of finish, but that was also always name alphabetical order, because we sorted the list and then worked through it sequentially in series. 

Do we care that the table is no longer alphabetically sorted? It's a quick fix if we do.
