### PR TITLE
Updating the elevation script to write elevation.xml

### DIFF
--- a/genet/utils/elevation.py
+++ b/genet/utils/elevation.py
@@ -1,5 +1,7 @@
 import rioxarray
 import numpy as np
+from lxml import etree
+import os
 
 
 def get_elevation_image(elevation_tif):
@@ -60,3 +62,22 @@ def validation_report_for_node_elevation(elev_dict, low_limit=-50, mont_blanc_he
                    'extremely_low_values_dict': too_low}}
 
     return report
+
+
+def write_slope_xml(links, output_dir):
+    fname = os.path.join(output_dir, 'link_slopes.xml')
+    print('Writing {}'.format(fname))
+
+    with open(fname, "wb") as f, etree.xmlfile(f, encoding='UTF-8') as xf:
+        xf.write_declaration(
+            doctype='<!DOCTYPE objectAttributes SYSTEM "http://matsim.org/files/dtd/objectattributes_v1.dtd">')
+        with xf.element("objectAttributes"):
+            for link_id, slope in links.items():
+                with xf.element("object", {'id': link_id}):
+                    attrib = {
+                        'name': 'slope',
+                        'class': 'java.lang.Double',
+                    }
+                    rec = etree.Element("attribute", attrib)
+                    rec.text = str(slope)
+                    xf.write(rec)

--- a/genet/utils/elevation.py
+++ b/genet/utils/elevation.py
@@ -8,6 +8,7 @@ def get_elevation_image(elevation_tif):
     xarr_file = rioxarray.open_rasterio(elevation_tif)
     if str(xarr_file.rio.crs) != 'EPSG:4326':
         xarr_file = xarr_file.rio.write_crs(4326, inplace=True)
+
     return xarr_file[0, :, :]
 
 
@@ -64,7 +65,12 @@ def validation_report_for_node_elevation(elev_dict, low_limit=-50, mont_blanc_he
     return report
 
 
-def write_slope_xml(links, output_dir):
+def write_slope_xml(link_slope_dictionary, output_dir):
+    """
+    Generates a link_slopes XML file.
+    :param link_slope_dictionary: dictionary of link slopes in format {link_id: {'slope': slope_value}}
+    :param output_dir: directory where the XML file will be written to
+    """
     fname = os.path.join(output_dir, 'link_slopes.xml')
     print('Writing {}'.format(fname))
 
@@ -72,12 +78,12 @@ def write_slope_xml(links, output_dir):
         xf.write_declaration(
             doctype='<!DOCTYPE objectAttributes SYSTEM "http://matsim.org/files/dtd/objectattributes_v1.dtd">')
         with xf.element("objectAttributes"):
-            for link_id, slope in links.items():
+            for link_id, slope_dict in link_slope_dictionary.items():
                 with xf.element("object", {'id': link_id}):
                     attrib = {
                         'name': 'slope',
                         'class': 'java.lang.Double',
                     }
                     rec = etree.Element("attribute", attrib)
-                    rec.text = str(slope)
+                    rec.text = str(slope_dict['slope'])
                     xf.write(rec)

--- a/scripts/add_elevation_to_network.py
+++ b/scripts/add_elevation_to_network.py
@@ -12,7 +12,8 @@ from genet.output.geojson import save_geodataframe
 import genet.utils.elevation as elevation
 
 if __name__ == '__main__':
-    arg_parser = argparse.ArgumentParser(description='Add elevation data to network nodes, validate it, and calculate link slopes.')
+    arg_parser = argparse.ArgumentParser(
+        description='Add elevation data to network nodes, validate it, and calculate link slopes.')
 
     arg_parser.add_argument('-n',
                             '--network',
@@ -51,6 +52,12 @@ if __name__ == '__main__':
                             default=True,
                             type=bool)
 
+    arg_parser.add_argument('-ws',
+                            '--write_slope_to_object_attribute_file',
+                            help='Whether link slope data should be written to object attribute file; defaults to True',
+                            default=True,
+                            type=bool)
+
     arg_parser.add_argument('-sj',
                             '--save_jsons',
                             help='Whether elevation and slope dictionaries and report are saved; defaults to True',
@@ -65,6 +72,7 @@ if __name__ == '__main__':
     output_dir = args['output_dir']
     write_elevation_to_network = args['write_elevation_to_network']
     write_slope_to_network = args['write_slope_to_network']
+    write_slope_to_object_attribute_file = args['write_slope_to_object_attribute_file']
     save_dict_to_json = args['save_jsons']
     elevation_output_dir = os.path.join(output_dir, 'elevation')
     ensure_dir(elevation_output_dir)
@@ -86,7 +94,6 @@ if __name__ == '__main__':
                   encoding='utf-8') as f:
             json.dump(sanitiser.sanitise_dictionary(elevation_dictionary), f, ensure_ascii=False, indent=4)
 
-
     logging.info('Validating the node elevation data')
     report = genet.utils.elevation.validation_report_for_node_elevation(elevation_dictionary)
     logging.info(report['summary'])
@@ -95,7 +102,6 @@ if __name__ == '__main__':
         with open(os.path.join(elevation_output_dir, 'validation_report_for_elevation.json'), 'w',
                   encoding='utf-8') as f:
             json.dump(sanitiser.sanitise_dictionary(report), f, ensure_ascii=False, indent=4)
-
 
     if write_elevation_to_network:
         logging.info('Adding node elevation as attribute to the network')
@@ -109,7 +115,6 @@ if __name__ == '__main__':
         gdf_nodes = gdf_nodes[['id', 'z', 'geometry']]
         save_geodataframe(gdf_nodes.to_crs('epsg:4326'), 'node_elevation', elevation_output_dir)
 
-
     logging.info('Creating slope dictionary for network links')
     slope_dictionary = n.get_link_slope_dictionary(elevation_dict=elevation_dictionary)
 
@@ -117,7 +122,6 @@ if __name__ == '__main__':
         with open(os.path.join(elevation_output_dir, 'link_slope_dictionary.json'), 'w',
                   encoding='utf-8') as f:
             json.dump(sanitiser.sanitise_dictionary(slope_dictionary), f, ensure_ascii=False, indent=4)
-
 
     if write_slope_to_network:
         logging.info('Adding link slope as an additional attribute to the network')
@@ -129,12 +133,14 @@ if __name__ == '__main__':
         n.apply_attributes_to_links(attrib_dict)
 
         gdf = n.to_geodataframe()['links']
-        df = pd.DataFrame(list(slope_dictionary.items()), columns = ['id','slope_tuple'])
+        df = pd.DataFrame(list(slope_dictionary.items()), columns=['id', 'slope_tuple'])
         df['slope'] = [x['slope'] for x in df['slope_tuple']]
         df = df[['id', 'slope']]
         gdf_links = pd.merge(gdf, df, on='id')
         save_geodataframe(gdf_links.to_crs('epsg:4326'), 'link_slope', elevation_output_dir)
 
+    if write_slope_to_object_attribute_file:
+        elevation.write_slope_xml(slope_dictionary, elevation_output_dir)
 
     logging.info('Writing the updated network')
     n.write_to_matsim(elevation_output_dir)

--- a/tests/test_data/elevation/link_slopes.xml
+++ b/tests/test_data/elevation/link_slopes.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE objectAttributes SYSTEM "http://matsim.org/files/dtd/objectattributes_v1.dtd">
+<objectAttributes><object id="0"><attribute name="slope" class="java.lang.Double">{'slope': 2.861737280890912}</attribute></object><object id="1"><attribute name="slope" class="java.lang.Double">{'slope': -0.1}</attribute></object></objectAttributes>

--- a/tests/test_data/elevation/link_slopes.xml
+++ b/tests/test_data/elevation/link_slopes.xml
@@ -1,3 +1,3 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE objectAttributes SYSTEM "http://matsim.org/files/dtd/objectattributes_v1.dtd">
-<objectAttributes><object id="0"><attribute name="slope" class="java.lang.Double">{'slope': 2.861737280890912}</attribute></object><object id="1"><attribute name="slope" class="java.lang.Double">{'slope': -0.1}</attribute></object></objectAttributes>
+<objectAttributes><object id="0"><attribute name="slope" class="java.lang.Double">2.861737280890912</attribute></object><object id="1"><attribute name="slope" class="java.lang.Double">-0.1</attribute></object></objectAttributes>

--- a/tests/test_utils_elevation.py
+++ b/tests/test_utils_elevation.py
@@ -3,12 +3,20 @@ import genet.utils.elevation as elevation
 import xarray as xr
 import os
 from tests.fixtures import assert_semantically_equal
+from tests import xml_diff
+
+
+@pytest.fixture()
+def slope_xml_file():
+    return os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "test_data", "elevation", "link_slopes.xml"))
 
 
 elevation_test_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "test_data", "elevation"))
 tif_path = os.path.join(elevation_test_folder, 'hk_elevation_example.tif')
 tif_path_crs_not_4326 = os.path.join(elevation_test_folder, 'hk_elevation_example_crs_2326.tif')
 array_path = os.path.join(elevation_test_folder, 'elevation_image.nc')
+
 
 def test_output_type_get_elevation_image():
     img = elevation.get_elevation_image(tif_path)
@@ -43,3 +51,11 @@ def test_validation_report_for_node_elevation_dictionary():
                       'values': {'extremely_high_values_dict': {}, 'extremely_low_values_dict': {'101982': -51}}}
 
     assert_semantically_equal(report, correct_report)
+
+
+def test_writing_slope_saves_data_to_xml(tmpdir, slope_xml_file):
+    slope_dictionary = {'0': {'slope': 2.861737280890912}, '1': {'slope': -0.1}}
+    elevation.write_slope_xml(slope_dictionary, tmpdir)
+
+    generated_elevation_file_path = os.path.join(tmpdir, 'link_slopes.xml')
+    xml_diff.assert_semantically_equal(generated_elevation_file_path, slope_xml_file)

--- a/tests/test_utils_elevation.py
+++ b/tests/test_utils_elevation.py
@@ -5,7 +5,6 @@ import os
 from tests.fixtures import assert_semantically_equal
 from tests import xml_diff
 
-
 @pytest.fixture()
 def slope_xml_file():
     return os.path.abspath(


### PR DESCRIPTION
While testing a multimodal network for the Sheffield ABM, we realised that MATSIM uses a separate `link_slopes.xml` rather than using the link slope written as attribute onto the network links. This PR adds a function `write_slope_xml` and edits the `add_elevation_to_network.py` script to use it.