### PR TITLE
fix method setting trips from headway breaking graph schema

### DIFF
--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -886,7 +886,7 @@ class Route(ScheduleElement):
             'vehicle_id': [f'veh_{self.mode}_{self.id}_{t}' for t in new_trip_departures]
         }
         if 'trips' in self.__dict__:
-            self._graph.graph['routes']['trips'] = trips
+            self._graph.graph['routes'][self.id]['trips'] = trips
             self._graph.graph['change_log'] = self.change_log().modify(
                 object_type='route', old_id=self.id, old_attributes=self.trips, new_id=self.id, new_attributes=trips)
         self.trips = trips

--- a/tests/test_core_components_route.py
+++ b/tests/test_core_components_route.py
@@ -2,7 +2,7 @@ import pytest
 import os
 from pandas import DataFrame, Timestamp
 from pandas.testing import assert_frame_equal
-from genet.schedule_elements import Route, Stop
+from genet.schedule_elements import Route, Stop, verify_graph_schema
 from genet.utils import plot
 from tests.fixtures import stop_epsg_27700, assert_semantically_equal, assert_logging_warning_caught_with_message_containing
 from genet.exceptions import ServiceIndexError
@@ -114,6 +114,14 @@ def test_updating_route_trips_with_headway(route):
          'vehicle_id': ['veh_bus_1_01:00:00', 'veh_bus_1_01:20:00', 'veh_bus_1_01:40:00', 'veh_bus_1_02:00:00',
                         'veh_bus_1_02:30:00', 'veh_bus_1_03:00:00']}
     )
+
+
+def test_generating_trips_from_headway_preserves_graph_schema(route):
+    verify_graph_schema(route.graph())
+
+    route.generate_trips_from_headway({('01:00:00', '02:00:00'): 20, ('02:00:00', '03:00:00'): 30})
+
+    verify_graph_schema(route.graph())
 
 
 def test__repr__shows_stops_and_trips_length(route):

--- a/tests/test_core_schedule.py
+++ b/tests/test_core_schedule.py
@@ -8,7 +8,7 @@ from geopandas.testing import assert_geodataframe_equal
 
 from genet.exceptions import ServiceIndexError, ConflictingStopData, InconsistentVehicleModeError
 from genet.input import read, matsim_reader, gtfs_reader
-from genet.schedule_elements import Schedule, Service, Route, Stop, read_vehicle_types
+from genet.schedule_elements import Schedule, Service, Route, Stop, read_vehicle_types, verify_graph_schema
 from genet.utils import plot, spatial
 from genet.validate import schedule as schedule_validation
 from tests.fixtures import *
@@ -1971,6 +1971,14 @@ def test_generating_trips_from_headway_creates_trips_with_vehicles(schedule):
          'vehicle_id': ['veh_bus_1_01:00:00', 'veh_bus_1_01:20:00', 'veh_bus_1_01:40:00', 'veh_bus_1_02:00:00',
                         'veh_bus_1_02:30:00', 'veh_bus_1_03:00:00']}
     )
+
+
+def test_generating_trips_from_headway_preserves_graph_schema(schedule):
+    verify_graph_schema(schedule.graph())
+
+    schedule.generate_trips_from_headway('1', {('01:00:00', '02:00:00'): 20, ('02:00:00', '03:00:00'): 30})
+
+    verify_graph_schema(schedule.graph())
 
 
 def test_generating_trips_from_headway_updates_vehicles(schedule):


### PR DESCRIPTION
Found when working on TE, using the method to generate trips from headways on a `Route` object level breaks the graph schema underlying the schedule. Test catching it before and after:
![Screenshot 2022-11-22 at 12 16 46](https://user-images.githubusercontent.com/36536946/203313508-fc484924-0e62-45c8-8479-e4bcd91e140f.png)
![Screenshot 2022-11-22 at 12 18 36](https://user-images.githubusercontent.com/36536946/203313516-52b219cc-6875-4e66-95ba-5c7f4142b915.png)
Added a similar test for schedule too for good measure, but there was no problem there.