### PR TITLE
Elevation script fixes

### DIFF
--- a/genet/__init__.py
+++ b/genet/__init__.py
@@ -8,3 +8,4 @@ from genet.exceptions import ScheduleElementGraphSchemaError, RouteInitialisatio
     ServiceInitialisationError  # noqa: F401
 from genet.utils import graph_operations  # noqa: F401
 from genet.utils import google_directions  # noqa: F401
+from genet.utils import elevation  # noqa: F401

--- a/genet/utils/elevation.py
+++ b/genet/utils/elevation.py
@@ -2,6 +2,7 @@ import rioxarray
 import numpy as np
 from lxml import etree
 import os
+import logging
 
 
 def get_elevation_image(elevation_tif):
@@ -72,7 +73,7 @@ def write_slope_xml(link_slope_dictionary, output_dir):
     :param output_dir: directory where the XML file will be written to
     """
     fname = os.path.join(output_dir, 'link_slopes.xml')
-    print('Writing {}'.format(fname))
+    logging.info(f'Writing {fname}')
 
     with open(fname, "wb") as f, etree.xmlfile(f, encoding='UTF-8') as xf:
         xf.write_declaration(

--- a/scripts/add_elevation_to_network.py
+++ b/scripts/add_elevation_to_network.py
@@ -42,19 +42,22 @@ if __name__ == '__main__':
 
     arg_parser.add_argument('-we',
                             '--write_elevation_to_network',
-                            help='Whether node elevation data should be written as attribute to the network; defaults to True',
+                            help='Whether node elevation data should be written as attribute to the network; '
+                                 'defaults to True',
                             default=True,
                             type=bool)
 
-    arg_parser.add_argument('-ws',
+    arg_parser.add_argument('-wsn',
                             '--write_slope_to_network',
-                            help='Whether link slope data should be written as attribute to the network; defaults to True',
+                            help='Whether link slope data should be written as attribute to the network; '
+                                 'defaults to True',
                             default=True,
                             type=bool)
 
-    arg_parser.add_argument('-ws',
+    arg_parser.add_argument('-wsoa',
                             '--write_slope_to_object_attribute_file',
-                            help='Whether link slope data should be written to object attribute file; defaults to True',
+                            help='Whether link slope data should be written to object attribute file; '
+                                 'defaults to True',
                             default=True,
                             type=bool)
 

--- a/scripts/add_elevation_to_network.py
+++ b/scripts/add_elevation_to_network.py
@@ -9,7 +9,6 @@ from genet import read_matsim
 from genet.utils.persistence import ensure_dir
 import genet.output.sanitiser as sanitiser
 from genet.output.geojson import save_geodataframe
-import genet.utils.elevation as elevation
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser(
@@ -98,7 +97,7 @@ if __name__ == '__main__':
             json.dump(sanitiser.sanitise_dictionary(elevation_dictionary), f, ensure_ascii=False, indent=4)
 
     logging.info('Validating the node elevation data')
-    report = genet.utils.elevation.validation_report_for_node_elevation(elevation_dictionary)
+    report = genet.elevation.validation_report_for_node_elevation(elevation_dictionary)
     logging.info(report['summary'])
 
     if save_dict_to_json:
@@ -143,7 +142,7 @@ if __name__ == '__main__':
         save_geodataframe(gdf_links.to_crs('epsg:4326'), 'link_slope', elevation_output_dir)
 
     if write_slope_to_object_attribute_file:
-        elevation.write_slope_xml(slope_dictionary, elevation_output_dir)
+        genet.elevation.write_slope_xml(slope_dictionary, elevation_output_dir)
 
     logging.info('Writing the updated network')
     n.write_to_matsim(elevation_output_dir)

--- a/scripts/add_elevation_to_network.py
+++ b/scripts/add_elevation_to_network.py
@@ -76,8 +76,7 @@ if __name__ == '__main__':
     write_slope_to_network = args['write_slope_to_network']
     write_slope_to_object_attribute_file = args['write_slope_to_object_attribute_file']
     save_dict_to_json = args['save_jsons']
-    elevation_output_dir = os.path.join(output_dir, 'elevation')
-    ensure_dir(elevation_output_dir)
+    ensure_dir(output_dir)
 
     logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.WARNING)
 
@@ -92,7 +91,7 @@ if __name__ == '__main__':
     elevation_dictionary = n.get_node_elevation_dictionary(elevation_tif_file_path=elevation, null_value=tif_null_value)
 
     if save_dict_to_json:
-        with open(os.path.join(elevation_output_dir, 'node_elevation_dictionary.json'), 'w',
+        with open(os.path.join(output_dir, 'node_elevation_dictionary.json'), 'w',
                   encoding='utf-8') as f:
             json.dump(sanitiser.sanitise_dictionary(elevation_dictionary), f, ensure_ascii=False, indent=4)
 
@@ -101,7 +100,7 @@ if __name__ == '__main__':
     logging.info(report['summary'])
 
     if save_dict_to_json:
-        with open(os.path.join(elevation_output_dir, 'validation_report_for_elevation.json'), 'w',
+        with open(os.path.join(output_dir, 'validation_report_for_elevation.json'), 'w',
                   encoding='utf-8') as f:
             json.dump(sanitiser.sanitise_dictionary(report), f, ensure_ascii=False, indent=4)
 
@@ -115,13 +114,13 @@ if __name__ == '__main__':
 
         gdf_nodes = n.to_geodataframe()['nodes']
         gdf_nodes = gdf_nodes[['id', 'z', 'geometry']]
-        save_geodataframe(gdf_nodes.to_crs('epsg:4326'), 'node_elevation', elevation_output_dir)
+        save_geodataframe(gdf_nodes.to_crs('epsg:4326'), 'node_elevation', output_dir)
 
     logging.info('Creating slope dictionary for network links')
     slope_dictionary = n.get_link_slope_dictionary(elevation_dict=elevation_dictionary)
 
     if save_dict_to_json:
-        with open(os.path.join(elevation_output_dir, 'link_slope_dictionary.json'), 'w',
+        with open(os.path.join(output_dir, 'link_slope_dictionary.json'), 'w',
                   encoding='utf-8') as f:
             json.dump(sanitiser.sanitise_dictionary(slope_dictionary), f, ensure_ascii=False, indent=4)
 
@@ -139,10 +138,10 @@ if __name__ == '__main__':
         df['slope'] = [x['slope'] for x in df['slope_tuple']]
         df = df[['id', 'slope']]
         gdf_links = pd.merge(gdf, df, on='id')
-        save_geodataframe(gdf_links.to_crs('epsg:4326'), 'link_slope', elevation_output_dir)
+        save_geodataframe(gdf_links.to_crs('epsg:4326'), 'link_slope', output_dir)
 
     if write_slope_to_object_attribute_file:
-        genet.elevation.write_slope_xml(slope_dictionary, elevation_output_dir)
+        genet.elevation.write_slope_xml(slope_dictionary, output_dir)
 
     logging.info('Writing the updated network')
-    n.write_to_matsim(elevation_output_dir)
+    n.write_to_matsim(output_dir)


### PR DESCRIPTION
Fixes:
- clashing argument flags `-ws`
- `import genet.utils.elevation as elevation` being overwritten by `elevation = args['elevation']` and preventing [`write_slope_to_object_attribute_file`](https://github.com/arup-group/genet/compare/elevation-script-fixes?expand=1#diff-99b2946aac5db3dd9ee2030e299fe866323e2dc3d2ed02fd93e16d1d066708edL142-R144)

As a bonus:
- gets rid of `elevation_output_dir = os.path.join(output_dir, 'elevation')` it's a needless extra folder (nothing gets saved anywhere else). User can decide if they want outputs saved to a folder called elevation or not