### PR TITLE
Use a different base image in the Docker file to fix the broken nativ…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.7-slim-stretch
+FROM python:3.7.16-bullseye
 
 RUN apt-get update && \
 apt-get upgrade -y && \
-apt-get -y install gcc git libspatialindex-dev curl coinor-cbc &&  \
+apt-get -y install gcc git libgdal-dev libgeos-dev libspatialindex-dev curl coinor-cbc &&  \
 rm -rf /var/lib/apt/lists/*
 
 RUN curl -sL https://deb.nodesource.com/setup_17.x | bash -


### PR DESCRIPTION
…e dependencies installation

## The Problem

As it stands, GeNet's `Dockerfile` is broken - the same error we see in the CD pipeline can be replicated when trying to build the image on my local machine.

```bash
docker build -t genet .

[+] Building 3.4s (6/12)
 => [internal] load build definition from Dockerfile                                                                                                                  0.0s
 => => transferring dockerfile: 653B                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                     0.0s
 => => transferring context: 71B                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/python:3.7-slim-stretch                                                                                            1.6s
 => [internal] load build context                                                                                                                                     0.0s
 => => transferring context: 34.67kB                                                                                                                                  0.0s
 => CACHED [1/8] FROM docker.io/library/python:3.7-slim-stretch@sha256:649b13bc3e6a70f7722d5eba4d78afbf4e9cec63193a29148271124840013286                               0.0s
 => ERROR [2/8] RUN apt-get update && apt-get upgrade -y && apt-get -y install gcc git libspatialindex-dev curl coinor-cbc &&  rm -rf /var/lib/apt/lists/*            1.7s
------
 > [2/8] RUN apt-get update && apt-get upgrade -y && apt-get -y install gcc git libspatialindex-dev curl coinor-cbc &&  rm -rf /var/lib/apt/lists/*:
#5 0.654 Ign:1 http://deb.debian.org/debian stretch InRelease
#5 0.654 Ign:2 http://security.debian.org/debian-security stretch/updates InRelease
#5 0.666 Ign:3 http://security.debian.org/debian-security stretch/updates Release
#5 0.666 Ign:4 http://deb.debian.org/debian stretch-updates InRelease
#5 0.677 Ign:5 http://deb.debian.org/debian stretch Release
#5 0.695 Ign:6 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#5 0.700 Ign:7 http://deb.debian.org/debian stretch-updates Release
#5 0.739 Ign:8 http://deb.debian.org/debian stretch/main arm64 Packages
#5 0.739 Ign:9 http://security.debian.org/debian-security stretch/updates/main all Packages
#5 0.959 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#5 0.973 Ign:6 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#5 0.976 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#5 0.988 Ign:9 http://security.debian.org/debian-security stretch/updates/main all Packages
#5 0.993 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#5 1.011 Ign:8 http://deb.debian.org/debian stretch/main arm64 Packages
#5 1.030 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#5 1.032 Ign:6 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#5 1.044 Ign:9 http://security.debian.org/debian-security stretch/updates/main all Packages
#5 1.047 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#5 1.065 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#5 1.070 Ign:6 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#5 1.082 Ign:8 http://deb.debian.org/debian stretch/main arm64 Packages
#5 1.082 Ign:9 http://security.debian.org/debian-security stretch/updates/main all Packages
#5 1.102 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#5 1.110 Ign:6 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#5 1.141 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#5 1.149 Ign:9 http://security.debian.org/debian-security stretch/updates/main all Packages
#5 1.159 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#5 1.190 Err:6 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#5 1.190   404  Not Found
#5 1.294 Ign:8 http://deb.debian.org/debian stretch/main arm64 Packages
#5 1.294 Ign:9 http://security.debian.org/debian-security stretch/updates/main all Packages
#5 1.314 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#5 1.426 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#5 1.454 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#5 1.472 Ign:8 http://deb.debian.org/debian stretch/main arm64 Packages
#5 1.489 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#5 1.506 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#5 1.552 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#5 1.570 Err:8 http://deb.debian.org/debian stretch/main arm64 Packages
#5 1.570   404  Not Found
#5 1.581 Ign:10 http://deb.debian.org/debian stretch/main all Packages
#5 1.599 Err:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#5 1.599   404  Not Found
#5 1.616 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#5 1.628 Reading package lists...
#5 1.643 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
#5 1.643 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
#5 1.643 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
#5 1.643 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-arm64/Packages  404  Not Found
#5 1.643 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-arm64/Packages  404  Not Found
#5 1.643 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-arm64/Packages  404  Not Found
#5 1.643 E: Some index files failed to download. They have been ignored, or old ones used instead.
------
executor failed running [/bin/sh -c apt-get update && apt-get upgrade -y && apt-get -y install gcc git libspatialindex-dev curl coinor-cbc &&  rm -rf /var/lib/apt/lists/*]: exit code: 100
```

The root cause is that some native dependencies we install into the image are no longer available, but on inspecting [the base Docker image](https://hub.docker.com/layers/library/python/3.7.7-slim-stretch/images/sha256-6ab3f1b840fb9757c8fb240c2eb63458b4ff503894a96cc4f10a36286f8acf75) I also found it has some high-severity security warnings.

I've switched to [a different Python 3.7 base image](https://hub.docker.com/layers/library/python/3.7.16-bullseye/images/sha256-719de36dcc6278954de7be2cf345ae98b734812688c416bd734041adf9728407?context=explore) that has no security warnings and required only minimal changes to keep everything running, but it has increased the image size considerably. For now I think it's best to fix the Docker file; later we can work on slimming the image down .
## Verifying the Image

### Building 
```bash
docker build -t local-genet .

docker images
REPOSITORY       TAG       IMAGE ID       CREATED        SIZE
local-genet      latest    7f909845356f   11 hours ago   2.35GB
```

It's a chonker, but I'll try to chop as much out of it as possible and create another PR when I've done that.

### Testing

```bash
docker run -it --entrypoint /bin/bash local-genet
```

#### Notebook smoke tests inside the container
```bash
root@8e788c33ca04:/# ./bash_scripts/notebooks-smoke-test.sh


 a,  8a
 `8, `8)                            ,adPPRg,
  8)  ]8                        ,ad888888888b
 ,8' ,8'                    ,gPPR888888888888
,8' ,8'                 ,ad8""   `Y888888888P
8)  8)              ,ad8""        (8888888""
8,  8,          ,ad8""            d888""
`8, `8,     ,ad8""            ,ad8""
 `8, `" ,ad8""            ,ad8""
    ,gPPR8b           ,ad8""
   dP:::::Yb      ,ad8""
   8):::::(8  ,ad8""
   Yb:;;;:d888""
    "8ggg8P"
 _   _ ____    ____  __  __  ___  _  _______   _____ _____ ____ _____
| \ | | __ )  / ___||  \/  |/ _ \| |/ / ____| |_   _| ____/ ___|_   _|
|  \| |  _ \  \___ \| |\/| | | | | ' /|  _|     | | |  _| \___ \ | |
| |\  | |_) |  ___) | |  | | |_| | . \| |___    | | | |___ ___) || |
|_| \_|____/  |____/|_|  |_|\___/|_|\_\_____|   |_| |_____|____/ |_|

Smoke testing Jupyter notebooks in 'notebooks' directory
Found 21 notebooks files in notebooks
['notebooks/1. Intro.ipynb',
 'notebooks/2.1. Reading Data: MATSim.ipynb',
 'notebooks/2.2. Reading Data: OSM.ipynb',
 'notebooks/2.3. Reading Data: GTFS.ipynb',
 'notebooks/2.4. Reading Data: CSV.ipynb',
 'notebooks/2.5. Reading Data: JSON & GeoJSON.ipynb',
 'notebooks/3.1. Writing Data: MATSim.ipynb',
 'notebooks/3.3. Writing Data: GTFS.ipynb',
 'notebooks/3.4. Writing Data: CSV.ipynb',
 'notebooks/3.5. Writing Data: JSON & GeoJSON.ipynb',
 'notebooks/4.1. Using Network: Accessing Data.ipynb',
 'notebooks/4.2. Using Network: Road Pricing.ipynb',
 'notebooks/4.3. Using Network: Routing.ipynb',
 'notebooks/4.4. Using Network: Auxiliary Files referencing Network IDs.ipynb',
 'notebooks/5.1. Modifying Network: Graph.ipynb',
 'notebooks/5.2. Modifying Network: PT Schedule.ipynb',
 'notebooks/5.3. Modifying Network: Simplification.ipynb',
 'notebooks/5.4. Modifying Network: Addition.ipynb',
 'notebooks/6.1. Validating Network: MATSim Specific.ipynb',
 'notebooks/6.2. Validating Network: Google Directions API.ipynb',
 'notebooks/7. Visualising Network.ipynb']
Making sure we have a Jupyter kernel called genet installed...
ipython kernel install --name "genet" --user
Installed kernelspec genet in /root/.local/share/jupyter/kernels/genet
Shell process return value for ['ipython', 'kernel', 'install', '--name', '"genet"', '--user'] was 0
Executing notebook 'notebooks/1. Intro.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/1. Intro.ipynb" --output-dir=/tmp
Executing notebook 'notebooks/2.2. Reading Data: OSM.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/2.2. Reading Data: OSM.ipynb" --output-dir=/tmp
Executing notebook 'notebooks/2.1. Reading Data: MATSim.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/2.1. Reading Data: MATSim.ipynb" --output-dir=/tmp
Executing notebook 'notebooks/2.3. Reading Data: GTFS.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/2.3. Reading Data: GTFS.ipynb" --output-dir=/tmp
Executing notebook 'notebooks/2.5. Reading Data: JSON & GeoJSON.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/2.5. Reading Data: JSON & GeoJSON.ipynb" --output-dir=/tmp
Executing notebook 'notebooks/2.4. Reading Data: CSV.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/2.4. Reading Data: CSV.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/2.3. Reading Data: GTFS.ipynb to notebook
[NbConvertApp] Converting notebook notebooks/1. Intro.ipynb to notebook
[NbConvertApp] Converting notebook notebooks/2.5. Reading Data: JSON & GeoJSON.ipynb to notebook
[NbConvertApp] Converting notebook notebooks/2.4. Reading Data: CSV.ipynb to notebook
[NbConvertApp] Converting notebook notebooks/2.2. Reading Data: OSM.ipynb to notebook
[NbConvertApp] Converting notebook notebooks/2.1. Reading Data: MATSim.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 5664 bytes to /tmp/2.4. Reading Data: CSV.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/2.4. Reading Data: CSV.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/3.1. Writing Data: MATSim.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/3.1. Writing Data: MATSim.ipynb" --output-dir=/tmp
[NbConvertApp] Writing 7141 bytes to /tmp/2.3. Reading Data: GTFS.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/2.3. Reading Data: GTFS.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/3.3. Writing Data: GTFS.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/3.3. Writing Data: GTFS.ipynb" --output-dir=/tmp
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Converting notebook notebooks/3.1. Writing Data: MATSim.ipynb to notebook
[NbConvertApp] Converting notebook notebooks/3.3. Writing Data: GTFS.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 15022 bytes to /tmp/2.1. Reading Data: MATSim.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/2.1. Reading Data: MATSim.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/3.4. Writing Data: CSV.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/3.4. Writing Data: CSV.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/3.4. Writing Data: CSV.ipynb to notebook
[NbConvertApp] Writing 14833 bytes to /tmp/2.5. Reading Data: JSON & GeoJSON.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/2.5. Reading Data: JSON & GeoJSON.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/3.5. Writing Data: JSON & GeoJSON.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/3.5. Writing Data: JSON & GeoJSON.ipynb" --output-dir=/tmp
[NbConvertApp] Writing 36733 bytes to /tmp/1. Intro.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/1. Intro.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/4.1. Using Network: Accessing Data.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/4.1. Using Network: Accessing Data.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/3.5. Writing Data: JSON & GeoJSON.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Converting notebook notebooks/4.1. Using Network: Accessing Data.ipynb to notebook
[NbConvertApp] Writing 14460 bytes to /tmp/3.3. Writing Data: GTFS.ipynb
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/3.3. Writing Data: GTFS.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/4.2. Using Network: Road Pricing.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/4.2. Using Network: Road Pricing.ipynb" --output-dir=/tmp
[NbConvertApp] Writing 14210 bytes to /tmp/2.2. Reading Data: OSM.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/2.2. Reading Data: OSM.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/4.3. Using Network: Routing.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/4.3. Using Network: Routing.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/4.2. Using Network: Road Pricing.ipynb to notebook
[NbConvertApp] Converting notebook notebooks/4.3. Using Network: Routing.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 7404 bytes to /tmp/3.1. Writing Data: MATSim.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/3.1. Writing Data: MATSim.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/4.4. Using Network: Auxiliary Files referencing Network IDs.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/4.4. Using Network: Auxiliary Files referencing Network IDs.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/4.4. Using Network: Auxiliary Files referencing Network IDs.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 5841 bytes to /tmp/3.4. Writing Data: CSV.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/3.4. Writing Data: CSV.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/5.1. Modifying Network: Graph.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/5.1. Modifying Network: Graph.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/5.1. Modifying Network: Graph.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 23735 bytes to /tmp/4.2. Using Network: Road Pricing.ipynb
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/4.2. Using Network: Road Pricing.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/5.2. Modifying Network: PT Schedule.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/5.2. Modifying Network: PT Schedule.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/5.2. Modifying Network: PT Schedule.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 6725 bytes to /tmp/3.5. Writing Data: JSON & GeoJSON.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/3.5. Writing Data: JSON & GeoJSON.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/5.3. Modifying Network: Simplification.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/5.3. Modifying Network: Simplification.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/5.3. Modifying Network: Simplification.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 32389 bytes to /tmp/4.4. Using Network: Auxiliary Files referencing Network IDs.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/4.4. Using Network: Auxiliary Files referencing Network IDs.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/5.4. Modifying Network: Addition.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/5.4. Modifying Network: Addition.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/5.4. Modifying Network: Addition.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 487761 bytes to /tmp/4.1. Using Network: Accessing Data.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/4.1. Using Network: Accessing Data.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/6.1. Validating Network: MATSim Specific.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/6.1. Validating Network: MATSim Specific.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/6.1. Validating Network: MATSim Specific.ipynb to notebook
[NbConvertApp] Writing 21163 bytes to /tmp/4.3. Using Network: Routing.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/4.3. Using Network: Routing.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/6.2. Validating Network: Google Directions API.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/6.2. Validating Network: Google Directions API.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/6.2. Validating Network: Google Directions API.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 54990 bytes to /tmp/5.1. Modifying Network: Graph.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/5.1. Modifying Network: Graph.ipynb"', '--output-dir=/tmp'] was 0
Executing notebook 'notebooks/7. Visualising Network.ipynb'...
jupyter nbconvert --to notebook --execute "notebooks/7. Visualising Network.ipynb" --output-dir=/tmp
[NbConvertApp] Converting notebook notebooks/7. Visualising Network.ipynb to notebook
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 148633 bytes to /tmp/5.2. Modifying Network: PT Schedule.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/5.2. Modifying Network: PT Schedule.ipynb"', '--output-dir=/tmp'] was 0
[NbConvertApp] Writing 13097 bytes to /tmp/5.3. Modifying Network: Simplification.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/5.3. Modifying Network: Simplification.ipynb"', '--output-dir=/tmp'] was 0
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 31055 bytes to /tmp/6.1. Validating Network: MATSim Specific.ipynb
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/6.1. Validating Network: MATSim Specific.ipynb"', '--output-dir=/tmp'] was 0
[NbConvertApp] Writing 76629 bytes to /tmp/6.2. Validating Network: Google Directions API.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/6.2. Validating Network: Google Directions API.ipynb"', '--output-dir=/tmp'] was 0
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 66082 bytes to /tmp/5.4. Modifying Network: Addition.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/5.4. Modifying Network: Addition.ipynb"', '--output-dir=/tmp'] was 0
/usr/local/lib/python3.7/site-packages/jupyter_client/manager.py:358: FutureWarning: Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).
  FutureWarning)
[NbConvertApp] Writing 1312259 bytes to /tmp/7. Visualising Network.ipynb
Shell process return value for ['jupyter', 'nbconvert', '--to', 'notebook', '--execute', '"notebooks/7. Visualising Network.ipynb"', '--output-dir=/tmp'] was 0
------------------------------------------------------

Finished the smoke test in 0:00:24.352356

                                   Smoke Test Summary
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┓
┃ Notebook                                                          ┃ Result ┃ Time    ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━┩
│ 2.4. Reading Data: CSV.ipynb                                      │ PASSED │ 0:00:02 │
│ 2.3. Reading Data: GTFS.ipynb                                     │ PASSED │ 0:00:02 │
│ 2.1. Reading Data: MATSim.ipynb                                   │ PASSED │ 0:00:04 │
│ 2.5. Reading Data: JSON & GeoJSON.ipynb                           │ PASSED │ 0:00:04 │
│ 1. Intro.ipynb                                                    │ PASSED │ 0:00:04 │
│ 3.3. Writing Data: GTFS.ipynb                                     │ PASSED │ 0:00:02 │
│ 2.2. Reading Data: OSM.ipynb                                      │ PASSED │ 0:00:05 │
│ 3.1. Writing Data: MATSim.ipynb                                   │ PASSED │ 0:00:04 │
│ 3.4. Writing Data: CSV.ipynb                                      │ PASSED │ 0:00:04 │
│ 4.2. Using Network: Road Pricing.ipynb                            │ PASSED │ 0:00:04 │
│ 3.5. Writing Data: JSON & GeoJSON.ipynb                           │ PASSED │ 0:00:05 │
│ 4.4. Using Network: Auxiliary Files referencing Network IDs.ipynb │ PASSED │ 0:00:04 │
│ 4.1. Using Network: Accessing Data.ipynb                          │ PASSED │ 0:00:08 │
│ 4.3. Using Network: Routing.ipynb                                 │ PASSED │ 0:00:08 │
│ 5.1. Modifying Network: Graph.ipynb                               │ PASSED │ 0:00:08 │
│ 5.2. Modifying Network: PT Schedule.ipynb                         │ PASSED │ 0:00:08 │
│ 5.3. Modifying Network: Simplification.ipynb                      │ PASSED │ 0:00:07 │
│ 6.1. Validating Network: MATSim Specific.ipynb                    │ PASSED │ 0:00:05 │
│ 6.2. Validating Network: Google Directions API.ipynb              │ PASSED │ 0:00:06 │
│ 5.4. Modifying Network: Addition.ipynb                            │ PASSED │ 0:00:10 │
│ 7. Visualising Network.ipynb                                      │ PASSED │ 0:00:07 │
└───────────────────────────────────────────────────────────────────┴────────┴─────────┘
                             0 failed, 21 passed in 0:00:24

/
root@8e788c33ca04:/#
```

#### Unit tests inside the container
```bash
root@8e788c33ca04:/# pytest -vv tests/

=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.7.16, pytest-7.3.1, pluggy-0.13.1 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /
plugins: mock-3.10.0, xdist-3.2.1, anyio-3.6.2, cov-4.0.0
collected 1021 items

tests/test_auxiliary_files.py::test_attaching_links_benchmark_to_network PASSED                                                                                     [  0%]
tests/test_auxiliary_files.py::test_building_identity_map_for_links_benchmark PASSED                                                                                [  0%]
tests/test_auxiliary_files.py::test_applying_map PASSED                                                                                                             [  0%]
tests/test_auxiliary_files.py::test_updating_links_benchmark PASSED                                                                                                 [  0%]
tests/test_auxiliary_files.py::test_saving_links_benchmark PASSED                                                                                                   [  0%]
tests/test_auxiliary_files.py::test_attaching_links_benchmark_csv_to_network PASSED                                                                                 [  0%]
tests/test_auxiliary_files.py::test_building_identity_map_for_links_benchmark_csv PASSED                                                                            [  0%]
tests/test_auxiliary_files.py::test_updating_links_benchmark_csv PASSED                                                                                             [  0%]
tests/test_auxiliary_files.py::test_saving_links_benchmark_csv PASSED                                                                                               [  0%]
...
tests/test_validate_schedule.py::test_schedule_with_multiple_use_vehicles PASSED                                                                                    [ 99%]
tests/test_validate_schedule.py::test_nice_schedules_global_headway_evaluation_in_validation_report PASSED                                                          [ 99%]
tests/test_validate_schedule.py::test_nice_schedules_headway_stats_in_validation_report PASSED                                                                      [ 99%]
tests/test_validate_schedule.py::test_bad_schedules_global_headway_evaluation_in_validation_report PASSED                                                           [ 99%]
tests/test_validate_schedule.py::test_bad_schedules_headway_stats_in_validation_report PASSED                                                                       [100%]
...
======================================================== 1020 passed, 1 xfailed, 139 warnings in 150.07s (0:02:30) ========================================================
```

## Continuous Deployment Build is Fixed
<img width="811" alt="Screenshot 2023-04-26 at 01 44 17" src="https://user-images.githubusercontent.com/250899/234438021-6e90821b-808a-459b-938e-e1ff306ac4de.png">

