### PR TITLE
Intermodal access egress validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-# [v3.0.0]
+# Changelog
 
-## What's Changed
+## [Unreleased]
 
-### New Features
+### Added
+* Validation for [intermodal access/egress for MATSim](https://github.com/matsim-org/matsim-libs/tree/master/contribs/sbb-extensions#intermodal-access-and-egress)
+
+## [v3.0.0] - 2022-07-14
+
+### Added
 * Addition of elevation and slope data to networks using [STRM](https://srtm.csi.cgiar.org/srtmdata/) files
 * Vehicle capacity and pce scaling
   * Conveniently save multiple `vehicle.xml` files for use with simulations at different scales: 1%, 5%, 10%, etc.
@@ -13,7 +18,7 @@
   * Script to add attributes to PT stops of various PT modes that allow agents to 
   access via network or teleported modes
 
-### Improvements
+### Changed
 * **[Breaking change]** New, **default**, representation of additional attributes
   ```python
   'attributes': {
@@ -34,19 +39,18 @@
     * `inputs_handler` -> `input`
     * `outputs_handler` -> `output` 
 
-# [v2.0.1-snapshot]
+## [v2.0.1-snapshot] - 2022-04-08
 
-## What's Changed
+### Changed
 * Loosen version constraints for various pytest-related dependencies by @mfitz in https://github.com/arup-group/genet/pull/114
-
 
 **Full Changelog**: https://github.com/arup-group/genet/compare/v2.0.0-snapshot...v2.0.1-snapshot
 
-# [v2.0.0-snapshot]
+## [v2.0.0-snapshot] - 2022-04-07
 
 Not production ready. No release notes other than the automated ones generated from commits.
 
-## What's Changed
+### Changed
 * update readme by @KasiaKoz in https://github.com/arup-group/genet/pull/53
 * Fix simplifications script's help message (LAB-990) by @mfitz in https://github.com/arup-group/genet/pull/54
 * Make link 'oneway' attribute optional when writing networks to disk by @mfitz in https://github.com/arup-group/genet/pull/56
@@ -99,14 +103,13 @@ Not production ready. No release notes other than the automated ones generated f
 * Reduce Docker image size by @mfitz in https://github.com/arup-group/genet/pull/113
 * Add/Remove Services and Routes in groups by @KasiaKoz in https://github.com/arup-group/genet/pull/112
 
-## New Contributors
+### New Contributors
 * @syhwawa made their first contribution in https://github.com/arup-group/genet/pull/88
 * @ana-kop made their first contribution in https://github.com/arup-group/genet/pull/96
 
 **Full Changelog**: https://github.com/arup-group/genet/compare/v1.0.0...v2.0.0-snapshot
 
-# [v1.0.0]
+## [v1.0.0] - 2021-02-01
 
-# Initial release
-
+### Initial release
 This is the first release, please check documentation/wiki for the usage guide

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -3041,6 +3041,19 @@ class Schedule(ScheduleElement):
     def has_self_loops(self):
         return list(nx.nodes_with_selfloops(self.graph()))
 
+    def intermodal_access_egress_attribute_keys(self):
+        return [node.name for node in
+                graph_operations.get_attribute_schema(self._graph.nodes(data=True), data=False).leaves if
+                'accessLinkId' in node.name]
+
+    def has_intermodal_access_egress_connections(self):
+        return bool(self.intermodal_access_egress_attribute_keys())
+
+    def intermodal_access_egress_connections(self):
+        attribute_keys = self.intermodal_access_egress_attribute_keys()
+        df = self.stop_attribute_data(keys=[{'attributes': key} for key in attribute_keys])
+        return df
+
     def validity_of_services(self):
         return [service.is_valid_service() for service in self.services()]
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -288,6 +288,7 @@ class NetworkForIntermodalAccessEgressTesting:
         ])
         self.intermodal_access_egress_attribute_keys = []
         self.intermodal_access_egress_connections_dataframe = None
+        self.invalid_intermodal_access_egress_connections = {}
 
     @property
     def expected_intermodal_access_egress_attribute_keys(self):
@@ -296,6 +297,10 @@ class NetworkForIntermodalAccessEgressTesting:
     @property
     def expected_intermodal_access_egress_connections_dataframe(self):
         return self.intermodal_access_egress_connections_dataframe
+
+    @property
+    def expected_invalid_intermodal_access_egress_connections(self):
+        return self.invalid_intermodal_access_egress_connections
 
     @property
     def schedule(self):
@@ -328,6 +333,44 @@ class NetworkForIntermodalAccessEgressTesting:
         self.intermodal_access_egress_attribute_keys = [access_link_id_tag]
         self.intermodal_access_egress_connections_dataframe = pd.DataFrame(
             {'attributes::accessLinkId_car': {'Stop_A': 'link_0', 'Stop_B': 'link_0'}})
+        self.invalid_intermodal_access_egress_connections = {
+            'car': {
+                'stops_with_links_not_in_network': set(),
+                'stops_with_links_with_wrong_modes': set()
+            }
+        }
+        return self
+
+    def with_invalid_intermodal_access_egress(self):
+        access_link_id_tag = 'accessLinkId_piggyback'
+        accessible_tag = 'piggybackAccessible'
+        distance_catchment_tag = 'piggyback_distance_catchment_tag'
+        new_stops_data = {
+            'Stop_A': {
+                'attributes': {
+                    access_link_id_tag: 'non_existent_link',  # stop with link that doesn't exist
+                    accessible_tag: 'true',
+                    distance_catchment_tag: 10
+                }
+            },
+            'Stop_B': {
+                'attributes': {
+                    access_link_id_tag: 'link_0',  # stop with link that doesn't have the right mode on it
+                    accessible_tag: 'true',
+                    distance_catchment_tag: 10
+                }
+            }
+        }
+        self.schedule.apply_attributes_to_stops(new_stops_data)
+        self.intermodal_access_egress_attribute_keys = [access_link_id_tag]
+        self.intermodal_access_egress_connections_dataframe = pd.DataFrame(
+            {'attributes::accessLinkId_piggyback': {'Stop_A': 'non_existent_link', 'Stop_B': 'link_0'}})
+        self.invalid_intermodal_access_egress_connections = {
+            'piggyback': {
+                'stops_with_links_not_in_network': {'Stop_A'},
+                'stops_with_links_with_wrong_modes': {'Stop_B'}
+            }
+        }
         return self
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -258,30 +258,44 @@ class NetworkForIntermodalAccessEgressTesting:
                  'lat': 51.52228713323965,
                  's2_id': 5221390328605860387}
         })
-        self.network.add_link('link_0', 'A', 'B',
-                              attribs={
-                                  'id': 'link_0',
-                                  'from': 'A',
-                                  'to': 'B',
-                                  'freespeed': 10,
-                                  'capacity': 600,
-                                  'permlanes': 1,
-                                  'oneway': '1',
-                                  'modes': ['car'],
-                                  's2_from': 5221390329378179879,
-                                  's2_to': 5221390328605860387,
-                                  'length': 53
-                              })
+        self.network.add_links({
+            'link_AB': {
+                'id': 'link_AB',
+                'from': 'A',
+                'to': 'B',
+                'freespeed': 10,
+                'capacity': 600,
+                'permlanes': 1,
+                'oneway': '1',
+                'modes': ['car', 'bus'],
+                's2_from': 5221390329378179879,
+                's2_to': 5221390328605860387,
+                'length': 53
+            },
+            'link_BA': {
+                'id': 'link_BA',
+                'from': 'B',
+                'to': 'A',
+                'freespeed': 10,
+                'capacity': 600,
+                'permlanes': 1,
+                'oneway': '1',
+                'modes': ['car', 'bus'],
+                's2_from': 5221390329378179879,
+                's2_to': 5221390328605860387,
+                'length': 53
+            }
+        })
         self.network.schedule = Schedule(epsg='epsg:27700', services=[
             Service(id='service',
                     routes=[
                         Route(id='route', route_short_name='route', mode='bus',
-                              stops=[Stop(id='Stop_A', x=528705, y=182069, epsg='epsg:27700', linkRefId='link_0'),
-                                     Stop(id='Stop_B', x=528836, y=182007, epsg='epsg:27700', linkRefId='link_0')],
+                              stops=[Stop(id='Stop_A', x=528705, y=182069, epsg='epsg:27700', linkRefId='link_AB'),
+                                     Stop(id='Stop_B', x=528836, y=182007, epsg='epsg:27700', linkRefId='link_BA')],
                               trips={'trip_id': ['trip_id_04:40:00'],
                                      'trip_departure_time': ['04:40:00'],
                                      'vehicle_id': ['veh_1_bus']},
-                              route=['link_0'],
+                              route=['link_AB', 'link_BA'],
                               arrival_offsets=['00:00:00', '00:02:00'],
                               departure_offsets=['00:00:00', '00:02:00'])
                     ])
@@ -316,14 +330,14 @@ class NetworkForIntermodalAccessEgressTesting:
         new_stops_data = {
             'Stop_A': {
                 'attributes': {
-                    access_link_id_tag: 'link_0',
+                    access_link_id_tag: 'link_AB',
                     accessible_tag: 'true',
                     distance_catchment_tag: 10
                 }
             },
             'Stop_B': {
                 'attributes': {
-                    access_link_id_tag: 'link_0',
+                    access_link_id_tag: 'link_BA',
                     accessible_tag: 'true',
                     distance_catchment_tag: 10
                 }
@@ -332,7 +346,7 @@ class NetworkForIntermodalAccessEgressTesting:
         self.schedule.apply_attributes_to_stops(new_stops_data)
         self.intermodal_access_egress_attribute_keys = [access_link_id_tag]
         self.intermodal_access_egress_connections_dataframe = pd.DataFrame(
-            {'attributes::accessLinkId_car': {'Stop_A': 'link_0', 'Stop_B': 'link_0'}})
+            {'attributes::accessLinkId_car': {'Stop_A': 'link_AB', 'Stop_B': 'link_BA'}})
         self.invalid_intermodal_access_egress_connections = {
             'car': {
                 'stops_with_links_not_in_network': set(),
@@ -355,7 +369,7 @@ class NetworkForIntermodalAccessEgressTesting:
             },
             'Stop_B': {
                 'attributes': {
-                    access_link_id_tag: 'link_0',  # stop with link that doesn't have the right mode on it
+                    access_link_id_tag: 'link_BA',  # stop with link that doesn't have the right mode on it
                     accessible_tag: 'true',
                     distance_catchment_tag: 10
                 }
@@ -364,7 +378,7 @@ class NetworkForIntermodalAccessEgressTesting:
         self.schedule.apply_attributes_to_stops(new_stops_data)
         self.intermodal_access_egress_attribute_keys = [access_link_id_tag]
         self.intermodal_access_egress_connections_dataframe = pd.DataFrame(
-            {'attributes::accessLinkId_piggyback': {'Stop_A': 'non_existent_link', 'Stop_B': 'link_0'}})
+            {'attributes::accessLinkId_piggyback': {'Stop_A': 'non_existent_link', 'Stop_B': 'link_BA'}})
         self.invalid_intermodal_access_egress_connections = {
             'piggyback': {
                 'stops_with_links_not_in_network': {'Stop_A'},

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -3143,6 +3143,9 @@ def test_nested_values_show_up_in_validation_report():
 def test_intermodal_access_egress_reporting(fixture, is_valid_network):
     report = fixture.network.generate_validation_report()
     assert report['is_valid_network'] == is_valid_network
+    assert report['intermodal_access_egress']['has_valid_intermodal_connections'] == is_valid_network
+    assert report['intermodal_access_egress']['invalid_intermodal_connections'] == \
+           fixture.invalid_intermodal_access_egress_connections
 
 
 def test_check_connectivity_for_mode_warns_of_graphs_with_more_than_single_component(mocker, caplog):

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -23,7 +23,8 @@ from genet.validate import network as network_validation
 from genet.input import read
 from genet import exceptions
 from tests.fixtures import assert_semantically_equal, route, stop_epsg_27700, network_object_from_test_data, \
-    full_fat_default_config_path, correct_schedule, vehicle_definitions_config_path
+    full_fat_default_config_path, correct_schedule, vehicle_definitions_config_path, \
+    NetworkForIntermodalAccessEgressTesting
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 pt2matsim_network_test_file = os.path.abspath(
@@ -2813,6 +2814,59 @@ def test_has_schedule_with_valid_network_routes_with_empty_routes(route):
     route.route = []
     n.schedule = Schedule(n.epsg, [Service(id='service', routes=[route, route])])
     assert not n.has_schedule_with_valid_network_routes()
+
+
+@pytest.mark.parametrize(
+    "fixture,has_intermodal_connections",
+    [
+        (NetworkForIntermodalAccessEgressTesting().without_intermodal_access_egress(), False),
+        (NetworkForIntermodalAccessEgressTesting().with_valid_car_intermodal_access_egress(), True),
+        (NetworkForIntermodalAccessEgressTesting().with_invalid_intermodal_access_egress(), True),
+    ]
+)
+def test_recognising_intermodal_connections(fixture, has_intermodal_connections):
+    assert fixture.network.has_intermodal_access_egress_connections() == has_intermodal_connections
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        NetworkForIntermodalAccessEgressTesting().without_intermodal_access_egress(),
+        NetworkForIntermodalAccessEgressTesting().with_valid_car_intermodal_access_egress(),
+        NetworkForIntermodalAccessEgressTesting().with_invalid_intermodal_access_egress(),
+    ]
+)
+def test_assembling_intermodal_access_egress_connections(fixture):
+    result = fixture.network.intermodal_access_egress_connections()
+    if isinstance(result, pd.DataFrame):
+        assert_frame_equal(result, fixture.intermodal_access_egress_connections_dataframe)
+    else:
+        assert result == fixture.intermodal_access_egress_connections_dataframe
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        NetworkForIntermodalAccessEgressTesting().without_intermodal_access_egress(),
+        NetworkForIntermodalAccessEgressTesting().with_valid_car_intermodal_access_egress(),
+        NetworkForIntermodalAccessEgressTesting().with_invalid_intermodal_access_egress(),
+    ]
+)
+def test_reporting_on_invalid_intermodal_connections(fixture):
+    invalid_intermodal_connections = fixture.network.invalid_intermodal_access_egress_connections()
+    assert invalid_intermodal_connections == fixture.expected_invalid_intermodal_access_egress_connections
+
+
+@pytest.mark.parametrize(
+    "fixture,has_valid_intermodal_connections",
+    [
+        (NetworkForIntermodalAccessEgressTesting().without_intermodal_access_egress(), True),
+        (NetworkForIntermodalAccessEgressTesting().with_valid_car_intermodal_access_egress(), True),
+        (NetworkForIntermodalAccessEgressTesting().with_invalid_intermodal_access_egress(), False),
+    ]
+)
+def test_declaration_on_valid_intermodal_connections(fixture, has_valid_intermodal_connections):
+    assert fixture.network.has_valid_intermodal_access_egress_connections() == has_valid_intermodal_connections
 
 
 def test_invalid_network_routes_with_valid_route(route):

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -3132,6 +3132,18 @@ def test_nested_values_show_up_in_validation_report():
         }
     )
 
+@pytest.mark.parametrize(
+    "fixture,is_valid_network",
+    [
+        (NetworkForIntermodalAccessEgressTesting().without_intermodal_access_egress(), True),
+        (NetworkForIntermodalAccessEgressTesting().with_valid_car_intermodal_access_egress(), True),
+        (NetworkForIntermodalAccessEgressTesting().with_invalid_intermodal_access_egress(), False),
+    ]
+)
+def test_intermodal_access_egress_reporting(fixture, is_valid_network):
+    report = fixture.network.generate_validation_report()
+    assert report['is_valid_network'] == is_valid_network
+
 
 def test_check_connectivity_for_mode_warns_of_graphs_with_more_than_single_component(mocker, caplog):
     mocker.patch.object(network_validation, 'describe_graph_connectivity',

--- a/tests/test_core_schedule.py
+++ b/tests/test_core_schedule.py
@@ -1628,6 +1628,22 @@ def test_has_self_loops_with_non_looping_routes(schedule):
     assert not schedule.has_self_loops()
 
 
+def test_schedule_without_intermodal_links_declares_it():
+    schedule = NetworkForIntermodalAccessEgressTesting().without_intermodal_access_egress().schedule
+    assert not schedule.has_intermodal_access_egress_connections()
+
+
+def test_schedule_with_intermodal_links_declares_it():
+    schedule = NetworkForIntermodalAccessEgressTesting().with_valid_car_intermodal_access_egress().schedule
+    assert schedule.has_intermodal_access_egress_connections()
+
+
+def test_intermodal_access_egress_dataframe_contents_with_well_defined_car_access():
+    fixture = NetworkForIntermodalAccessEgressTesting().with_valid_car_intermodal_access_egress()
+    df = fixture.schedule.intermodal_access_egress_connections()
+    assert_frame_equal(df, fixture.expected_intermodal_access_egress_connections_dataframe)
+
+
 def test_validity_of_services(self_looping_route, route):
     s = Schedule('epsg:27700', [Service(id='1', routes=[self_looping_route]),
                                 Service(id='2', routes=[route])])


### PR DESCRIPTION
As seen on one of our projects, deleting a link that served as an intermodal access/egress point to a PT stop resulted in the following MATSim error:

```java
java.lang.NullPointerException: Cannot invoke "org.matsim.api.core.v01.network.Link.getToNode()" because "link" is null
	at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorRoutingModule.findCoordinate(SwissRailRaptorRoutingModule.java:97) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
	at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorRoutingModule.fillWithActivities(SwissRailRaptorRoutingModule.java:73) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
	at ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorRoutingModule.calcRoute(SwissRailRaptorRoutingModule.java:60) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
	at org.matsim.core.router.TripRouter.calcRoute(TripRouter.java:183) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
	at org.matsim.core.router.PlanRouter.run(PlanRouter.java:102) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
	at org.matsim.core.population.algorithms.PersonPrepareForSim.run(PersonPrepareForSim.java:234) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
	at org.matsim.core.population.algorithms.ParallelPersonAlgorithmUtils$PersonAlgoThread.run(ParallelPersonAlgorithmUtils.java:146) ~[columbus-2.1.0-jar-with-dependencies.jar:2.1.0]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

This PR adds convenience methods to view intermodal connections and to generate validation summary of invalid intermodal connections. The connections are tested against two criteria:
- whether the link exists in the network (the point of failure on our project)
- if the link exists, whether the link accepts the mode that it is used for access/egress (e.g. the link is declared under `accessLinkId_car` attribute for the PT stop, but `car` does not feature in the `modes` attribute of the link)

Resolves https://github.com/arup-group/genet/issues/183