### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN /usr/local/bin/python -m pip install --no-cache-dir --compile --upgrade pip
 COPY ./scripts .
 COPY . .
 
+RUN pip3 install cmake>=3
 RUN pip3 install --no-cache-dir --compile -e . && pip cache purge
 ENV PYTHONPATH=./scripts:${PYTHONPATH}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ anytree < 2.9
 boto3 < 1.30
 dictdiffer < 1
 flake8 >= 6, < 7
-gdal < 3.6
 geopandas >= 0.13, < 0.15
 ipykernel < 7
 keplergl < 0.4


### PR DESCRIPTION
docker image is failing in main branch with 
```
#0 120.7        5495 | OGRFieldDomainShadow* CreateCodedFieldDomain( const char *name,
#0 120.7             |                       ^~~~~~~~~~~~~~~~~~~~~~
#0 120.7       g++ -pthread -shared build/temp.linux-aarch64-cpython-311/extensions/gnm_wrap.o -L../../.libs -L../../ -L/usr/local/lib -L/usr/lib -lgdal -o build/lib.linux-aarch64-cpython-311/osgeo/_gnm.cpython-311-aarch64-linux-gnu.so
#0 120.7       error: command '/usr/bin/gcc' failed with exit code 1
#0 120.7       [end of output]
#0 120.7   
#0 120.7   note: This error originates from a subprocess, and is likely not a problem with pip.
#0 120.7   ERROR: Failed building wheel for gdal
...
#0 123.3           raise RuntimeError("CMake must be installed to build the following extensions: " +
#0 123.3       RuntimeError: CMake must be installed to build the following extensions: cmake_example
#0 123.3       [end of output]
#0 123.3   
#0 123.3   note: This error originates from a subprocess, and is likely not a problem with pip.
#0 123.3   ERROR: Failed building wheel for osmium
...
#0 248.9 ERROR: Could not build wheels for gdal, osmium, which is required to install pyproject.toml-based projects
```
[link](https://arupconsulting.slack.com/archives/CNASXCHM2/p1697539631558879) to broken docker build notification in slack

`cmake` add to docker image handles `osmium` and removing `gdal` from requirements fixes the `gdal` problem - `geopadas` handles that install.

Verified the image locally by running tests:
```
$ docker run genet -m pytest -vv tests
...
=========== 1063 passed, 1 xfailed, 64 warnings in 290.11s (0:04:50) ===========
```

[link](https://arupconsulting.slack.com/archives/CNASXCHM2/p1697544366553629) to passing docker build notification in slack