### PR TITLE
Update `Dockerfile` and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+* GeNet's pre-baked python scripts have been retired in favour of CLI [#194](https://github.com/arup-group/genet/pull/194)
+* **[Breaking change]** Support for python v3.11, updated to more accurate pyproj version [#192](https://github.com/arup-group/genet/pull/192)
+
 ## [v4.0.0] - 2023-08-22
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,9 @@ rm -rf /var/lib/apt/lists/*
 
 RUN /usr/local/bin/python -m pip install --no-cache-dir --compile --upgrade pip
 
-COPY ./scripts .
 COPY . .
 
 RUN pip3 install cmake>=3
 RUN pip3 install --no-cache-dir --compile -e . && pip cache purge
-ENV PYTHONPATH=./scripts:${PYTHONPATH}
 
-ENTRYPOINT ["python3"]
+ENTRYPOINT ["genet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,3 @@ COPY . .
 RUN pip3 install cmake>=3
 RUN pip3 install --no-cache-dir --compile -e . && pip cache purge
 
-ENTRYPOINT ["genet"]

--- a/README.md
+++ b/README.md
@@ -61,33 +61,41 @@ Docker is the recommended way to use GeNet if you do not plan to make any code c
 
     docker build -t "genet" .
 
-#### Running a container with a pre-baked script
+#### Using the cli inside a container
 
-    docker run genet reproject_network.py -h
-    
-    usage: reproject_network.py [-h] -n NETWORK [-s SCHEDULE] [-v VEHICLES] -cp
-                                CURRENT_PROJECTION -np NEW_PROJECTION
-                                [-p PROCESSES] -od OUTPUT_DIR
-    
-    Reproject a MATSim network
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -n NETWORK, --network NETWORK
-                            Location of the network.xml file
-      -s SCHEDULE, --schedule SCHEDULE
-                            Location of the schedule.xml file
-      -v VEHICLES, --vehicles VEHCILES
-      							  Location of the vehicles.xml file
-      -cp CURRENT_PROJECTION, --current_projection CURRENT_PROJECTION
-                            The projection network is currently in, eg.
-                            "epsg:27700"
-      -np NEW_PROJECTION, --new_projection NEW_PROJECTION
-                            The projection desired, eg. "epsg:27700"
-      -p PROCESSES, --processes PROCESSES
-                            The number of processes to split computation across
-      -od OUTPUT_DIR, --output_dir OUTPUT_DIR
-                            Output directory for the reprojected network
+    docker run genet --help
+
+to show the list of available commands, and e.g.
+
+    docker run genet simplify-network --help
+
+to show description of the command and parameters:
+```commandline
+Usage: genet simplify-network [OPTIONS]
+
+  Simplify a MATSim network by removing intermediate links from paths
+
+Options:
+  -n, --network PATH              Location of the input network.xml file
+                                  [required]
+  -s, --schedule PATH             Location of the input schedule.xml file
+  -v, --vehicles PATH             Location of the input vehicles.xml file
+  -p, --projection TEXT           The projection network is in, eg.
+                                  "epsg:27700"  [required]
+  -pp, --processes INTEGER        Number of parallel processes to split
+                                  process across
+  -vsc, --vehicle_scalings TEXT   Comma delimited list of scales for vehicles
+  -od, --output_dir DIRECTORY     Output directory  [required]
+  -fc, --force_strongly_connected_graph
+                                  If True, checks for disconnected subgraphs
+                                  for modes `walk`, `bike` and `car`. If there
+                                  are more than one strongly connected
+                                  subgraph, genet connects them with links at
+                                  closest points in the graph. The links used
+                                  to connect are weighted at 20% of
+                                  surrounding freespeed and capacity values.
+  --help                          Show this message and exit.
+```
 
 Otherwise, you can [install `genet` as a python package](#installation-as-a-python-package), in your base installation
 of python or a virtual environment.
@@ -97,10 +105,10 @@ inspect or change it and save it out to file. Check out the
 [example jupyter notebooks](https://github.com/arup-group/genet/tree/master/notebooks) 
 for usage examples.
 
-### Installation as a Python Package
+### Installation as a Python Package / CLI
 **Note:** if you plan only to _use_ GeNet rather than make code changes to it, you can avoid having to perform any
-local installation by using [GeNet's Docker image](#using-docker). If you are going to make code changes, or you don't
-want to use Docker for some reason...
+local installation by using [GeNet's Docker image](#using-docker). If you are going to make code changes or use GeNet's
+CLI locally, follow the steps below:
 
 #### Native dependencies
 GeNet uses some Python libraries that rely on underlying native libraries for things like geospatial calculations and
@@ -139,7 +147,7 @@ Create and activate a Python virtual environment
     source venv/bin/activate
 
 #### Install GeNet in to the virtual environment
-Finally install `GeNet`'s Python dependencies
+Finally, install `GeNet`'s Python dependencies
 
     pip install -e .
 
@@ -151,7 +159,6 @@ use the visualisation methods. To see the maps in a jupyter notebook, make sure 
 jupyter nbextension enable --py widgetsnbextension
 ```
 
-
 ## Developing GeNet
 
 We welcome community contributions to GeNet; please see our [guide to contributing](CONTRIBUTING.md) and our
@@ -160,8 +167,13 @@ described below to verify that the code still works. All of the following comman
 directory.
 
 ### Unit tests
+To run unit tests within genet python environment:
 
     python -m pytest -vv tests
+
+and within a docker container:
+
+    docker run --entrypoint "python" genet -m pytest -vv tests
 
 ### Generate a unit test code coverage report
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ Each `Route` class object has an attribute `stops` which consists of `genet.Stop
 information for the PT stop.
 
 
-
 ## Setup
 
-To run pre-baked scripts that use GeNet in a number of different scenarios you can use docker, which will save you the
+GeNet CLI supports a number of different usage scenarios. For these you can use docker, which will save you the
 work of installing GeNet locally:
 
 ### Using Docker
@@ -59,15 +58,15 @@ Docker is the recommended way to use GeNet if you do not plan to make any code c
 
 #### Build the image
 
-    docker build -t "genet" .
+    docker build -t "cml-genet" .
 
 #### Using the cli inside a container
 
-    docker run genet --help
+    docker run cml-genet genet --help
 
 to show the list of available commands, and e.g.
 
-    docker run genet simplify-network --help
+    docker run cml-genet genet simplify-network --help
 
 to show description of the command and parameters:
 ```commandline
@@ -97,15 +96,34 @@ Options:
   --help                          Show this message and exit.
 ```
 
-Otherwise, you can [install `genet` as a python package](#installation-as-a-python-package), in your base installation
-of python or a virtual environment.
-Run the pre-baked scripts, write your own scripts or use IPython shell or Jupyter Notebook to load up a network, 
-inspect or change it and save it out to file. Check out the 
+Note, you will reference data outside the docker container as inputs, the docker command will need the path to data
+mounted and be referenced according to the alias given, e.g.
+
+    docker run -v /local/path/:/mnt/ cml-genet genet simplify-network --network /mnt/network.xml [...]
+
+If the input network file lives at `/local/path/network.xml`.
+
+#### Running custom script inside a container
+
+Say you write a script `/local/path/my_genet_scripts/script.py` and you want to run it inside a docker container. 
+You will need to mount the local path to the container for the script to be found and use the generic `python` 
+as part of your command:
+
+    docker run -v /local/path/:/mnt/ cml-genet python /mnt/my_genet_scripts/script.py
+
+Note, if you reference data inside your script, or pass them as arguments to the script, they need to reference the 
+aliased path inside the container, here: `/mnt/`, rather than the path `/local/path/`.
+
+### Installation as a Python Package / CLI
+
+You can in your base installation of python or a virtual environment.
+You can use GeNet's CLI to run pre-baked modifications or checks on networks.
+You can also write your own python scripts, importing genet as a package, use IPython shell or Jupyter Notebook to load 
+up a network, inspect or change it and save it out to file. Check out the 
 [wiki pages](https://github.com/arup-group/genet/wiki/Functionality-and-Usage-Guide) and 
 [example jupyter notebooks](https://github.com/arup-group/genet/tree/master/notebooks) 
 for usage examples.
 
-### Installation as a Python Package / CLI
 **Note:** if you plan only to _use_ GeNet rather than make code changes to it, you can avoid having to perform any
 local installation by using [GeNet's Docker image](#using-docker). If you are going to make code changes or use GeNet's
 CLI locally, follow the steps below:
@@ -151,6 +169,14 @@ Finally, install `GeNet`'s Python dependencies
 
     pip install -e .
 
+After installation, you should be able to successfully run the help command to see all possible commands:
+
+    genet --help
+
+To inspect a specific command, run e.g.:
+
+    genet simplify-network --help
+
 #### Install Kepler dependencies
 
 Please follow [kepler's installation instructions](https://docs.kepler.gl/docs/keplergl-jupyter#install) to be able to 
@@ -173,7 +199,7 @@ To run unit tests within genet python environment:
 
 and within a docker container:
 
-    docker run --entrypoint "python" genet -m pytest -vv tests
+    docker run cml-genet python -m pytest -vv tests
 
 ### Generate a unit test code coverage report
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ To run unit tests within genet python environment:
 
 and within a docker container:
 
-    docker run cml-genet python -m pytest -vv tests
+    docker run cml-genet pytest -vv tests
 
 ### Generate a unit test code coverage report
 


### PR DESCRIPTION
PR to https://github.com/arup-group/genet/pull/194 which converts all scripts to CLI.

This PR adds changes to `Dockerfile` to support this - I went with no entry point. My reasoning is that it makes it flexible to run both genet CLI and custom scripts without overriding the entry point - which is a bit of a headache if using an AWS batch job for example.

If the docker image is named something else, like 'cml-genet' then it doesn't look too crazy I think... (see the docs) - but I'm  looking for feedback on this decision.

Docker image is building: [slack build notification](https://arupconsulting.slack.com/archives/CNASXCHM2/p1698156704065569), and tests inside passing
```
$ docker run cml-genet python -m pytest -vv tests
...
=========== 1063 passed, 1 xfailed, 82 warnings in 279.00s (0:04:38) ===========
```