### PR TITLE
Fix MacOS installation instructions for the coiner solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ The solver you use needs to support MILP - mixed integer linear programming.
 The commands for installing the necessary native libraries vary according to the operating system you are using, for
 example:
 
-| OS       | Commands |
-|----------|----------|
-|Mac OS    | `brew install spatialindex` <br/> `brew install gdal --HEAD` <br/> `brew install gdal` <br/> `brew tap coin-or-tools/coinor` <br/> `brew install coin-or-tools/coinor/cbc`|
-|Ubuntu    | `sudo apt install libspatialindex-dev` <br/> `sudo apt install libgdal-dev` <br/> `sudo apt install coinor-cbc`|
+| OS       | Commands                                                                                                                                                                          |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|Mac OS    | `brew install spatialindex` <br/> `brew install gdal --HEAD` <br/> `brew install gdal` <br/> `brew tap coin-or-tools/coinor` <br/> `brew install coin-or-tools/coinor/cbc` <br/> `brew install cbc` |
+|Ubuntu    | `sudo apt install libspatialindex-dev` <br/> `sudo apt install libgdal-dev` <br/> `sudo apt install coinor-cbc`                                                                   |
 
 #### Install dev prereqs
 (Use equivalent linux or Windows package management as appropriate for your environment)

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ The solver you use needs to support MILP - mixed integer linear programming.
 The commands for installing the necessary native libraries vary according to the operating system you are using, for
 example:
 
-| OS       | Commands                                                                                                                                                                          |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|Mac OS    | `brew install spatialindex` <br/> `brew install gdal --HEAD` <br/> `brew install gdal` <br/> `brew tap coin-or-tools/coinor` <br/> `brew install coin-or-tools/coinor/cbc` <br/> `brew install cbc` |
-|Ubuntu    | `sudo apt install libspatialindex-dev` <br/> `sudo apt install libgdal-dev` <br/> `sudo apt install coinor-cbc`                                                                   |
+| OS       | Commands                                                                                                                                                                                                                      |
+|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|Mac OS    | `brew install boost` <br/> `brew install spatialindex` <br/> `brew install gdal --HEAD` <br/> `brew install gdal` <br/> `brew tap coin-or-tools/coinor` <br/> `brew install coin-or-tools/coinor/cbc` <br/> `brew install cbc` |
+|Ubuntu    | `sudo apt install libspatialindex-dev` <br/> `sudo apt install libgdal-dev` <br/> `sudo apt install coinor-cbc`                                                                                                               |
 
 #### Install dev prereqs
 (Use equivalent linux or Windows package management as appropriate for your environment)


### PR DESCRIPTION
Today was the first time I tried to install and test GeNet on my new(er) M2 machine, and I found that 15 unit tests were failing due to the absence of the CBC coiner solver, despite my having followed the installation instructions from the README. After figuring out what was missing, I have added two additional commands to the section of the README about installing native dependencies on a Mac.

You can see the rendered section of the README [here](https://github.com/arup-group/genet/tree/fix_macos_coiner_install_instructions#installing-the-native-dependencies).