### PR TITLE
Clean up Docker image to fix hanging build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,12 @@ FROM python:3.11.4-bullseye
 
 RUN apt-get update && \
 apt-get upgrade -y && \
-apt-get -y install gcc git libgdal-dev libgeos-dev libspatialindex-dev curl coinor-cbc &&  \
+apt-get -y install gcc git libgdal-dev libgeos-dev libspatialindex-dev curl coinor-cbc cmake &&  \
 rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://deb.nodesource.com/setup_17.x | bash -
-RUN apt-get -y install nodejs && node --version && npm --version &&  \
-rm -rf /var/lib/apt/lists/*
+RUN python -m pip install --no-cache-dir --compile --upgrade pip
 
-RUN /usr/local/bin/python -m pip install --no-cache-dir --compile --upgrade pip
+COPY . ./src
 
-COPY . .
-
-RUN pip3 install cmake>=3
-RUN pip3 install --no-cache-dir --compile -e . && pip cache purge
+RUN pip3 install --no-cache-dir --compile -e ./src && pip cache purge
 


### PR DESCRIPTION
Fixes #211. 

I've purged `nodejs` while I'm here, but the main fix is copying the repo into a subdirectory of root and then pip installing it. 