### PR TITLE
Make geoparquet the new standard for ouptuts

### DIFF
--- a/genet/core.py
+++ b/genet/core.py
@@ -2613,7 +2613,7 @@ class Network:
         self, output_dir, gtfs_day="19700101", include_geojson_files=False, include_shp_files=False
     ):
         """
-        Generates spatial geoparquet that can be used for generating standard visualisations.
+        Generates spatial geoparquet files that can be used for visualisations.
         These can also be used for validating network for example inspecting link capacity, freespeed, number of lanes,
         the shape of modal subgraphs.
         :param output_dir: path to folder where to save resulting files

--- a/genet/output/geojson.py
+++ b/genet/output/geojson.py
@@ -270,11 +270,11 @@ def generate_standard_outputs(
             logging.warning(f"Your network is missing a vital attribute {attribute}")
 
     logging.info("Generating geojson outputs for different highway tags in car modal subgraph")
-    highway_tags = n.link_attribute_data_under_key({"attributes": {"osm:way:highway": "text"}})
+    highway_tags = n.link_attribute_data_under_key({"attributes": "osm:way:highway"})
     highway_tags = set(chain.from_iterable(highway_tags.apply(lambda x: persistence.setify(x))))
     for tag in highway_tags:
         tag_links = n.extract_links_on_edge_attributes(
-            conditions={"attributes": {"osm:way:highway": {"text": tag}}}, mixed_dtypes=True
+            conditions={"attributes": {"osm:way:highway": tag}}, mixed_dtypes=True
         )
         save_geodataframe(
             graph_links[graph_links["id"].isin(tag_links)],

--- a/genet/output/geojson.py
+++ b/genet/output/geojson.py
@@ -72,9 +72,9 @@ def save_geodataframe(
     :param _gdf: GeoDataFrame to save to disk
     :param filename: name of the file, without extension
     :param output_dir: path to folder where to save the file
-    :param to_parquet: whether to save to parquet file format, defaults to yes
-    :param to_geojson: whether to save to parquet file format, defaults to no
-    :param to_shp: whether to save to shape file format, defaults to no
+    :param to_parquet: whether to save to parquet file format, defaults to True
+    :param to_geojson: whether to save to parquet file format, defaults to False
+    :param to_shp: whether to save to shape file format, defaults to False
     :return: None, files are saved to disk
     """
     if not gdf.empty:

--- a/genet/output/sanitiser.py
+++ b/genet/output/sanitiser.py
@@ -14,11 +14,10 @@ def sanitise_list(x):
 def sanitise_geodataframe(gdf):
     if isinstance(gdf, GeoSeries):
         gdf = GeoDataFrame(gdf)
-    gdf = gdf.fillna("None")
     object_columns = gdf.select_dtypes(["object"]).columns
     for col in object_columns:
         if gdf[col].apply(lambda x: isinstance(x, (set, list))).any():
-            gdf[col] = gdf[col].apply(lambda x: ",".join(x))
+            gdf[col] = gdf[col].apply(lambda x: ",".join(x) if isinstance(x, (list, set)) else x)
         elif gdf[col].apply(lambda x: isinstance(x, dict)).any():
             gdf[col] = gdf[col].apply(lambda x: str(x))
     for col in gdf.select_dtypes(include=number).columns.tolist():

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -3526,11 +3526,11 @@ class Schedule(ScheduleElement):
         self, output_dir, gtfs_day="19700101", include_geojson_files=False, include_shp_files=False
     ):
         """
-        Generates geojsons that can be used for generating standard kepler visualisations.
-        These can also be used for validating network for example inspecting link capacity, freespeed, number of lanes,
+        Generates spatial geoparquet files that can be used for visualisations.
+        These can also be used for validating the schedule for example inspecting the stops and
         the shape of modal subgraphs.
-        :param output_dir: path to folder where to save resulting geojsons
-        :param gtfs_day: day in format YYYYMMDD for the network's schedule for consistency in visualisations,
+        :param output_dir: path to folder where to save resulting files
+        :param gtfs_day: day in format YYYYMMDD for the schedule for consistency in visualisations,
         defaults to 1970/01/01 otherwise
         :param include_geojson_files: whether to generate geojson outputs as well
         :param include_shp_files: whether to generate shape file outputs as well

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ osmnx < 2
 pandas >= 1.5, < 2.1
 polyline >= 2, < 3
 pre-commit < 4
+pyarrow > 14
 pyomo >= 6, < 7
 pyproj >= 3, < 4
 pyyaml >= 6, < 7

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,8 +60,8 @@ def test_add_elevation_to_network(invoke_runner_and_check_files):
             "link_slopes.xml",
             "network.xml",
             "node_elevation_dictionary.json",
-            os.path.join("supporting_outputs", "link_slope.geojson"),
-            os.path.join("supporting_outputs", "node_elevation.geojson"),
+            os.path.join("supporting_outputs", "link_slope.parquet"),
+            os.path.join("supporting_outputs", "node_elevation.parquet"),
             "validation_report_for_elevation.json",
         ],
     )
@@ -96,14 +96,14 @@ def test_generate_standard_outputs(invoke_runner_and_check_files):
             f"--projection={PROJECTION}",
         ],
         expected_files=[
-            "network_nodes.geojson",
-            "schedule_nodes.geojson",
+            "network_nodes.parquet",
+            "schedule_nodes.parquet",
             "summary_report.json",
-            "network_links.geojson",
-            "schedule_links.geojson",
-            os.path.join("schedule", "speed", "pt_network_speeds.geojson"),
-            os.path.join("schedule", "speed", "pt_speeds.geojson"),
-            os.path.join("routing", "schedule_network_routes_geodataframe.geojson"),
+            "network_links.parquet",
+            "schedule_links.parquet",
+            os.path.join("schedule", "speed", "pt_network_speeds.parquet"),
+            os.path.join("schedule", "speed", "pt_speeds.parquet"),
+            os.path.join("routing", "schedule_network_routes_geodataframe.parquet"),
         ],
     )
 
@@ -213,8 +213,8 @@ def test_separate_modes_in_network(invoke_runner_and_check_files):
         expected_files=[
             "validation_report.json",
             "network.xml",
-            os.path.join("supporting_outputs", "mode_bus_after.geojson"),
-            os.path.join("supporting_outputs", "mode_bus_before.geojson"),
+            os.path.join("supporting_outputs", "mode_bus_after.parquet"),
+            os.path.join("supporting_outputs", "mode_bus_before.parquet"),
         ],
     )
 
@@ -256,11 +256,11 @@ def test_squeeze_external_area(invoke_runner_and_check_files):
         ],
         expected_files=[
             "network.xml",
-            os.path.join("supporting_outputs", "external_network_links.geojson"),
-            os.path.join("supporting_outputs", "capacity_before.geojson"),
-            os.path.join("supporting_outputs", "freespeed_after.geojson"),
-            os.path.join("supporting_outputs", "capacity_after.geojson"),
-            os.path.join("supporting_outputs", "freespeed_before.geojson"),
+            os.path.join("supporting_outputs", "external_network_links.parquet"),
+            os.path.join("supporting_outputs", "capacity_before.parquet"),
+            os.path.join("supporting_outputs", "freespeed_after.parquet"),
+            os.path.join("supporting_outputs", "capacity_after.parquet"),
+            os.path.join("supporting_outputs", "freespeed_before.parquet"),
         ],
     )
 
@@ -280,11 +280,11 @@ def test_squeeze_urban_links(invoke_runner_and_check_files):
         ],
         expected_files=[
             "network.xml",
-            os.path.join("supporting_outputs", "capacity_before.geojson"),
-            os.path.join("supporting_outputs", "freespeed_after.geojson"),
-            os.path.join("supporting_outputs", "urban_network_links.geojson"),
-            os.path.join("supporting_outputs", "capacity_after.geojson"),
-            os.path.join("supporting_outputs", "freespeed_before.geojson"),
+            os.path.join("supporting_outputs", "capacity_before.parquet"),
+            os.path.join("supporting_outputs", "freespeed_after.parquet"),
+            os.path.join("supporting_outputs", "urban_network_links.parquet"),
+            os.path.join("supporting_outputs", "capacity_after.parquet"),
+            os.path.join("supporting_outputs", "freespeed_before.parquet"),
         ],
     )
 

--- a/tests/test_output_geojson.py
+++ b/tests/test_output_geojson.py
@@ -104,36 +104,6 @@ def test_generating_network_graph_geodataframe(assert_semantically_equal, networ
     assert links.crs == "EPSG:27700"
 
 
-def test_writing_spatial_produces_files(tmpdir):
-    n = Network("epsg:27700")
-    n.add_nodes(
-        {
-            "0": {"x": 528704, "y": 182068, "s2_id": 7860190995130875979},
-            "1": {"x": 528805, "y": 182169, "s2_id": 7860190995130875123},
-        }
-    )
-    n.add_links(
-        {
-            "link_0": {
-                "id": "link_0",
-                "from": "0",
-                "to": "1",
-                "length": 123,
-                "modes": ["car", "walk"],
-                "something": "yes",
-            },
-            "link_1": {
-                "id": "link_1",
-                "from": "1",
-                "to": "0",
-                "length": 123,
-                "modes": ["car", "walk"],
-            },
-        }
-    )
-    n.write_spatial(tmpdir, to_parquet=True, to_geojson=True, to_shp=True)
-
-
 def test_generating_schedule_graph_geodataframe(assert_semantically_equal, network):
     gdfs = gngeojson.generate_geodataframes(network.schedule.graph())
     nodes, links = gdfs["nodes"], gdfs["links"]

--- a/tests/test_output_geojson.py
+++ b/tests/test_output_geojson.py
@@ -24,13 +24,7 @@ def network(correct_schedule):
         attribs={
             "length": 123,
             "modes": ["bike"],
-            "attributes": {
-                "osm:way:highway": {
-                    "name": "osm:way:highway",
-                    "class": "java.lang.String",
-                    "text": "unclassified",
-                }
-            },
+            "attributes": {"osm:way:highway": {"unclassified"}},
         },
     )
     n.add_link("link_2", "1", "0", attribs={"length": 123, "modes": ["rail"]})

--- a/tests/test_output_geojson.py
+++ b/tests/test_output_geojson.py
@@ -24,7 +24,7 @@ def network(correct_schedule):
         attribs={
             "length": 123,
             "modes": ["bike"],
-            "attributes": {"osm:way:highway": {"unclassified"}},
+            "attributes": {"osm:way:highway": "unclassified"},
         },
     )
     n.add_link("link_2", "1", "0", attribs={"length": 123, "modes": ["rail"]})
@@ -65,13 +65,7 @@ def test_generating_network_graph_geodataframe(assert_semantically_equal, networ
         "length": {"link_0": 123, "link_1": 123, "link_2": 123},
         "attributes": {
             "link_0": float("nan"),
-            "link_1": {
-                "osm:way:highway": {
-                    "name": "osm:way:highway",
-                    "class": "java.lang.String",
-                    "text": "unclassified",
-                }
-            },
+            "link_1": {"osm:way:highway": "unclassified"},
             "link_2": float("nan"),
         },
         "to": {"link_0": "1", "link_1": "1", "link_2": "0"},


### PR DESCRIPTION
GeNet generates a selection of geojson outputs for network eye-ball validation and visualisation.
For large networks these can be very slow and clunky. The files also take up more space on disk.
So with @Theodore-Chatziioannou suggestion, this PR changes the default output format for standard outputs. It also tidies up the three spatial output file options for networks/schedules.

Londinium network links output goes from 13.8MB to 2.2MB 🚀 

Since I was already in that neck of the woods (standard outputs generation), I stumbled on a known problem and fixed: https://github.com/arup-group/genet/issues/156