### PR TITLE
Add github pages configuration and some basic docs pages

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Report a bug that leads to GeNet not working as expected.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us what you expected to happen.
+      placeholder: Tell us what you see!
+      value: "Something unexpected happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: operating-systems
+    attributes:
+      label: Which operating systems have you used?
+      description: You may select more than one.
+      placeholder: Windows
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: What version of GeNet are you using?
+      placeholder: v4.0.0
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false

--- a/.github/workflows/ISSUE_TEMPLATE/DOCS.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/DOCS.yml
@@ -1,0 +1,53 @@
+name: Report a documentation issue
+description: Missing, incorrect, or confusing information in our docs? Report a documentation issue
+labels:
+  - documentation
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        Please describe the inconsistency or issue you have found in
+        [our documentation](https://arup-group.github.io/genet)
+        or indicate where you feel there is a need for improvement. Furthermore,
+        explain the severity of the issue, i.e., its impact on you and potentially
+        other users.
+    validations:
+      required: true
+
+  - type: textarea
+    id: related-links
+    attributes:
+      label: Related links
+      description: >-
+        Please list all links to the sections of [our documentation](https://arup-group.github.io/genet)
+        that are impacted by the issue you described above. If applicable,
+        add screenshots. Additionally, list links to possibly related open
+        and closed [issues](https://github.com/arup-group/genet/issues)
+        and [discussions](https://github.com/arup-group/genet/discussions)
+        you encountered when searching our issue tracker.
+      value: |
+        -
+        -
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: What version of the documentation are you refering to?
+      placeholder: v4.0.0
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed change
+      description: >-
+        This field is optional. You may provide an improvement proposal for our
+        documentation by describing your suggestion in the text field below or
+        creating a pull request after reporting this issue referencing the issue.

--- a/.github/workflows/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -1,0 +1,24 @@
+name: Feature Request
+description: Suggest an idea for GeNet.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for letting us know about your idea!
+  - type: textarea
+    id: description
+    attributes:
+      label: What can be improved?
+      placeholder: Tell us what you would like to see!
+      value: "GeNet should include flying car routes!"
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: What version of GeNet are you using?
+      placeholder: v4.0.0
+    validations:
+      required: true

--- a/.github/workflows/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -11,7 +11,7 @@ body:
     attributes:
       label: What can be improved?
       placeholder: Tell us what you would like to see!
-      value: "GeNet should include flying car routes!"
+      value: "GeNet should support 'piggyback' mode when building networks from OSM data."
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ISSUE_TEMPLATE/config.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: Development docs CI
+
+on:
+  push:
+    branches:
+      - "**"
+    paths-ignore:
+      - tests/**
+
+jobs:
+  docs-test:
+    if: github.ref != 'refs/heads/main'
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    with:
+      deploy_type: test
+      notebook_kernel: genet
+
+  docs-update-latest:
+    permissions:
+      contents: write
+    if: github.ref == 'refs/heads/main'
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    with:
+      deploy_type: update_latest
+      notebook_kernel: genet

--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,9 @@ instance/
 # Scrapy stuff:
 .scrapy
 
-# Sphinx documentation
-docs/_build/
+# Documentation
+.docs
+mike-*.yml
 
 # PyBuilder
 target/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,9 @@ To contribute changes:
 
 Before submitting a pull request, check whether you have:
 
-* Added your changes to `CHANGELOG.md`.
-* Added or updated documentation for your changes.
-* Added tests if you implemented new functionality.
+- Added your changes to `CHANGELOG.md`.
+- Added or updated documentation for your changes.
+- Added tests if you implemented new functionality or fixed a bug.
 
 When opening a pull request, please provide a clear summary of your changes!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,46 +45,82 @@ input data should be included.
 See this page on [Creating an issue](https://github.com/arup-group/genet/issues) on GitHub to learn how to submit an
 issue.
 
-## Contributing Code - Pull Request Process
+## Submitting changes
 
-To find beginner-friendly issues you may want to work on, look [here](https://github.com/arup-group/genet/contribute).
+Look at the [development guide in our documentation](https://arup-group.github.io/genet/contributing) for information on how to get set up for development.
 
-1. All new work is done in a branch taken from master, details can be found here:
-[feature branch workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow)
-2. Ensure your work is covered by unit tests to the required percentage level. This script
-[`bash_scripts/code-coverage.sh`](https://github.com/arup-group/genet/blob/master/bash_scripts/code-coverage.sh)
- will help both in checking that the coverage level is satisfied and investigating places in code that have not been
- covered by the tests (via an output file `reports/coverage/index.html` which can be viewed in a browser).
-3. Ensure the sample notebooks execute without error by running `./bash_scripts/notebooks-smoke-test.sh`. Problems in
-the core GeNet APIs or in the notebooks themselves can both cause notebook failures.
-4. Provide [docstrings](https://www.python.org/dev/peps/pep-0257/) for new methods.
-5. Run `pre-commit install` to ensure your code is linted and formatted whenever you commit changes.
-6. Add or update dependencies in `requirements.txt` if applicable
-7. Ensure the CI build pipeline (Actions tab in GitHub) completes successfully for your branch. The pipeline performs
-automated `PEP8` checks and runs unit tests in a fresh environment, as well as installation of all dependencies.
-8. Update/add to or generate a new jupyter notebook in `notebooks` directory which takes the user through your new feature or
-change.
-   1. Jupyter notebooks are closely linked to the [wiki pages](https://github.com/arup-group/genet/wiki).
-      1. Make sure you follow the naming convention to title your page: `number.number. Theme: Catchy Title`
-      2. Make sure to also name the notebook so that it is machine readable: `number_number_theme_catchy_title.ipynb`
-      3. Make sure you structure the notebook in a way that you would like to see it in a wiki page, with a lot of
-      markdown cells containing quality descriptions. Use existing notebook as examples.
-   2. After your changes have been merged, you may like to update the wiki pages. To do this in an automated way:
-      1. Clone the wiki part of the repo: ```git clone https://github.com/arup-group/genet.wiki.git```
-      2. Run the `examples/generate_usage_wiki_from_notebooks.py` script, pointing at the folder containing the
-      notebooks and the wiki repo folder to receive the output.
-   3. You may use example data already in `examples/example_data` directory of this repo, or add more (small amount of) data to
-   it to show off your new features.
-9. Add section in the `README.md` which shows usage of your new feature. This can be paraphrased from the jupyter
-notebook in point above.
-10. If the feature is to be used in an automated workflow through the docker image, create n example script in the
-`scripts` directory. Please use existing scripts as templates.
-11. Submit your Pull Request (see [GitHub Docs on Creating a Pull Request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)),
- describing the feature, linking to any relevant GitHub issues and request review from at
-least two developers. (Please take a look at latest commits to find out which developers you should request review from)
-12. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
-do not have permission to do that, please request one of the reviewers to merge it for you.
+<!--- the "--8<--" html comments define what part of this file to add to the index page of the documentation -->
+<!--- --8<-- [start:docs] -->
+
+To contribute changes:
+
+1. Fork the project on GitHub.
+2. Create a feature branch to work on in your fork (`git checkout -b new-fix-or-feature`).
+3. Test your changes using `pytest`.
+4. Commit your changes to the feature branch (you should have `pre-commit` installed to ensure your code is correctly formatted when you commit changes).
+5. Push the branch to GitHub (`git push origin new-fix-or-feature`).
+6. On GitHub, create a new [pull request](https://github.com/arup-group/genet/pull/new/main) from the feature branch.
+
+### Pull requests
+
+Before submitting a pull request, check whether you have:
+
+* Added your changes to `CHANGELOG.md`.
+* Added or updated documentation for your changes.
+* Added tests if you implemented new functionality.
+
+When opening a pull request, please provide a clear summary of your changes!
+
+### Commit messages
+
+Please try to write clear commit messages. One-line messages are fine for small changes, but bigger changes should look like this:
+
+    A brief summary of the commit (max 50 characters)
+
+    A paragraph or bullet-point list describing what changed and its impact,
+    covering as many lines as needed.
+
+### Code conventions
+
+Start reading our code and you'll get the hang of it.
+
+We mostly follow the official [Style Guide for Python Code (PEP8)](https://www.python.org/dev/peps/pep-0008/).
+
+We have chosen to use the uncompromising code formatter [`black`](https://github.com/psf/black/) and the linter [`ruff`](https://beta.ruff.rs/docs/).
+When run from the root directory of this repo, `pyproject.toml` should ensure that formatting and linting fixes are in line with our custom preferences (e.g., 100 character maximum line length).
+The philosophy behind using `black` is to have uniform style throughout the project dictated by code.
+Since `black` is designed to minimise diffs, and make patches more human readable, this also makes code reviews more efficient.
+To make this a smooth experience, you should run `pre-commit install` after setting up your development environment, so that `black` makes all the necessary fixes to your code each time you commit, and so that `ruff` will highlight any errors in your code.
+If you prefer, you can also set up your IDE to run these two tools whenever you save your files, and to have `ruff` highlight erroneous code directly as you type.
+Take a look at their documentation for more information on configuring this.
+
+We require all new contributions to have docstrings for all modules, classes and methods.
+When adding docstrings, we request you use the [Google docstring style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
+
+## Release checklist
+
+### Pre-release
+
+- [ ] Make sure all unit and integration tests pass (This is best done by creating a pre-release pull request).
+- [ ] Re-run tutorial Jupyter notebooks (`pytest examples/ --overwrite`).
+- [ ] Make sure documentation builds without errors (`mike deploy [version]`, where `[version]` is the current minor release of the form `X.Y`).
+- [ ] Make sure the [changelog][changelog] is up-to-date, especially that new features and backward incompatible changes are clearly marked.
+
+### Create release
+
+- [ ] Bump the version number in `genet/__init__.py`
+- [ ] Update the [changelog][changelog] with final version number of the form `vX.Y.Z`, release date, and github `compare` link (at the bottom of the page).
+- [ ] Commit with message `Release vX.Y.Z`, then add a `vX.Y.Z` tag.
+- [ ] Create a release pull request to verify that the conda package builds successfully.
+- [ ] Once the PR is approved and merged, create a release through the GitHub web interface, using the same tag, titling it `Release vX.Y.Z` and include all the changelog elements that are *not* flagged as **internal**.
+
+### Post-release
+
+- [ ] Update the changelog, adding a new `[Unreleased]` heading.
+- [ ] Update `genet/__init__.py` to the next version appended with `.dev0`, in preparation for the next main commit.
+
+<!--- --8<-- [end:docs] -->
 
 ## Attribution
 
-The Contribution Guide was adapted from [PurpleBooth's Template](https://gist.github.com/PurpleBooth/b24679402957c63ec426).
+The Contribution Guide was adapted from [PurpleBooth's Template](https://gist.github.com/PurpleBooth/b24679402957c63ec426) and the [Calliope project's contribution guidelines](https://github.com/calliope-project/calliope/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ GeNet provides tools to represent and work with a multi-modal transport network 
 services. It is based on [MATSim's](https://www.matsim.org/) representation of such networks.
 
 The goal of GeNet is to:
+
 - Provide a formalised in-memory data structure for representing a multi-modal network with a PT service
 - Enable using the data structure for tasks such as generating auxiliary MATSim files e.g. Road Pricing
 - Simplify the process of modifying a network and provide a simple change log to track the differences between the input
@@ -93,7 +94,7 @@ ipython kernel install --user --name=genet
 ## Building the documentation
 
 If you are unable to access the online documentation, you can build the documentation locally.
-First, [install a development environment of genet](https://arup-group.github.io/genet/latest/contributing/coding/), then deploy the documentation using [mike](https://github.com/jimporter/mike):
+First, [install a development environment of genet](#installing-a-development-environment), then deploy the documentation using [mike](https://github.com/jimporter/mike):
 
 ```
 mike deploy develop

--- a/README.md
+++ b/README.md
@@ -1,24 +1,7 @@
+<!--- --8<-- [start:docs] -->
 # Network Scenario Generator (GeNet)
 
 [![DOI](https://zenodo.org/badge/265256468.svg)](https://zenodo.org/badge/latestdoi/265256468)
-
-
-## Table of Contents
-- [Overview](#overview)
-- [Setup](#setup)
-  * [Using Docker](#using-docker)
-    + [Building the image](#build-the-image)
-    + [Running GeNet from the container](#running-a-container-with-a-pre-baked-script)
-  * [Installation as a Python Package](#installation-as-a-python-package)
-    + [Installing a development environment](#installing-a-development-environment)
-    + [A note on the mathematical solver](#a-note-on-the-mathematical-solver)
-- [Developing GeNet](#developing-genet)
-  * [Unit tests](#unit-tests)
-  * [Code coverage report](#generate-a-unit-test-code-coverage-report)
-  * [Linting](#lint-the-python-code)
-
-
-## Overview
 
 GeNet provides tools to represent and work with a multi-modal transport network with public transport (PT)
 services. It is based on [MATSim's](https://www.matsim.org/) representation of such networks.
@@ -41,144 +24,80 @@ classes: the `Schedule` relies on a list of `genet.Service`'s, which in turn con
 Each `Route` class object has an attribute `stops` which consists of `genet.Stops` objects. The `Stops` carry spatial
 information for the PT stop.
 
-
-## Setup
-
-GeNet CLI supports a number of different usage scenarios. For these you can use docker, which will save you the
-work of installing GeNet locally:
-
-### Using Docker
-Docker is the recommended way to use GeNet if you do not plan to make any code changes.
-
-#### Build the image
-
-    docker build -t "cml-genet" .
-
-#### Using the cli inside a container
-
-    docker run cml-genet genet --help
-
-to show the list of available commands, and e.g.
-
-    docker run cml-genet genet simplify-network --help
-
-to show description of the command and parameters:
-```commandline
-Usage: genet simplify-network [OPTIONS]
-
-  Simplify a MATSim network by removing intermediate links from paths
-
-Options:
-  -n, --network PATH              Location of the input network.xml file
-                                  [required]
-  -s, --schedule PATH             Location of the input schedule.xml file
-  -v, --vehicles PATH             Location of the input vehicles.xml file
-  -p, --projection TEXT           The projection network is in, eg.
-                                  "epsg:27700"  [required]
-  -pp, --processes INTEGER        Number of parallel processes to split
-                                  process across
-  -vsc, --vehicle_scalings TEXT   Comma delimited list of scales for vehicles
-  -od, --output_dir DIRECTORY     Output directory  [required]
-  -fc, --force_strongly_connected_graph
-                                  If True, checks for disconnected subgraphs
-                                  for modes `walk`, `bike` and `car`. If there
-                                  are more than one strongly connected
-                                  subgraph, genet connects them with links at
-                                  closest points in the graph. The links used
-                                  to connect are weighted at 20% of
-                                  surrounding freespeed and capacity values.
-  --help                          Show this message and exit.
-```
-
-Note, you will reference data outside the docker container as inputs, the docker command will need the path to data
-mounted and be referenced according to the alias given, e.g.
-
-    docker run -v /local/path/:/mnt/ cml-genet genet simplify-network --network /mnt/network.xml [...]
-
-If the input network file lives at `/local/path/network.xml`.
-
-#### Running custom script inside a container
-
-Say you write a script `/local/path/my_genet_scripts/script.py` and you want to run it inside a docker container.
-You will need to mount the local path to the container for the script to be found and use the generic `python`
-as part of your command:
-
-    docker run -v /local/path/:/mnt/ cml-genet python /mnt/my_genet_scripts/script.py
-
-Note, if you reference data inside your script, or pass them as arguments to the script, they need to reference the
-aliased path inside the container, here: `/mnt/`, rather than the path `/local/path/`.
-
-### Installation as a Python Package
-
 You can use GeNet's CLI to run pre-baked modifications or checks on networks.
 You can also write your own python scripts, importing genet as a package, use IPython shell or Jupyter Notebook to load up a network, inspect or change it and save it out to file.
-Check out the [wiki pages](https://github.com/arup-group/genet/wiki/Functionality-and-Usage-Guide) and [example jupyter notebooks](https://github.com/arup-group/genet/tree/master/notebooks) for usage examples.
 
-**Note:** if you plan only to _use_ GeNet rather than make code changes to it, you can ignore the rest of this section and instead use [GeNet's Docker image](#using-docker).
-If you are going to make code changes or use GeNet's CLI locally, follow the steps below to [install a development environment](#installing-a-development-environment).
+<!--- --8<-- [end:docs] -->
 
-### Installing a development environment
+## Documentation
 
-To create a development environment for genet, with all libraries required for development and quality assurance installed, it is easiest to install genet using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager, as follows:
+For more detailed instructions, see our [documentation](https://arup-group.github.io/genet/latest).
 
-1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
-2. Open the command line (or the "miniforge prompt" in Windows).
-3. Download (a.k.a., clone) the genet repository: `git clone git@github.com:arup-group/genet.git`
-4. Change into the `genet` directory: `cd genet`
-5. Create the genet mamba environment: `mamba create -n genet -c conda-forge -c city-modelling-lab --file requirements/base.txt --file requirements/dev.txt`
-6. Activate the genet mamba environment: `mamba activate genet`
-7. Install the genet package into the environment, in editable mode and ignoring dependencies (we have dealt with those when creating the mamba environment): `pip install --no-deps -e .`
-8. Create a jupyter kernel linked to the environment to enable example notebook testing: `ipython kernel install --user --name=genet`
+## Installation
 
-All together:
+If you do not plan to make any code changes, you can install GeNet as a [Docker image](#as-a-docker-image) or a [Python package](#as-a-python-package).
+
+For more detailed instructions, see our [documentation](https://arup-group.github.io/genet/latest/installation/).
+
+### As a Docker image
+
+<!--- --8<-- [start:docs-install-docker] -->
+```shell
+git clone git@github.com:arup-group/genet.git
+cd genet
+docker build -t "cml-genet" .
+```
+<!--- --8<-- [end:docs-install-docker] -->
+
+### As a Python package
+
+To install genet (indexed online as cml-genet), we recommend using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager:
+
+<!--- --8<-- [start:docs-install-user] -->
 ``` shell
 git clone git@github.com:arup-group/genet.git
 cd genet
-mamba create -n genet -c conda-forge -c city-modelling-lab --file requirements/base.txt --file requirements/dev.txt
+mamba create -n genet -c conda-forge --file requirements/base.txt
+mamba activate genet
+pip install --no-deps .
+```
+<!--- --8<-- [end:docs-install-user] -->
+
+## Contributing
+
+There are many ways to contribute to genet.
+Before making contributions to the genet source code, see our contribution guidelines and follow the [development install instructions](#installing-a-development-environment).
+
+If you plan to make changes to the code then please make regular use of the following tools to verify the codebase while you work:
+
+- `pre-commit`: run `pre-commit install` in your command line to load inbuilt checks that will run every time you commit your changes.
+The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [pep8 standard](https://peps.python.org/pep-0008/).
+You can also run these checks yourself at any time to ensure staged changes are clean by simple calling `pre-commit`.
+- `pytest` - run the unit test suite and check test coverage.
+
+For more information, see our [documentation](https://arup-group.github.io/genet/latest/contributing/).
+
+### Installing a development environment
+
+<!--- --8<-- [start:docs-install-dev] -->
+``` shell
+git clone git@github.com:arup-group/genet.git
+cd genet
+mamba create -n genet -c conda-forge --file requirements/base.txt --file requirements/dev.txt
 mamba activate genet
 pip install --no-deps -e .
 ipython kernel install --user --name=genet
 ```
+<!--- --8<-- [end:docs-install-dev] -->
 
-#### A note on the mathematical solver
+## Building the documentation
 
-**Note**: The default CBC solver is pre-installed inside [GeNet's Docker image](#using-docker), which can save you some
-installation effort
+If you are unable to access the online documentation, you can build the documentation locally.
+First, [install a development environment of genet](https://arup-group.github.io/genet/latest/contributing/coding/), then deploy the documentation using [mike](https://github.com/jimporter/mike):
 
-To use methods which snap public transit to the graph, GeNet uses a mathematical solver.
-If you won't be using such functionality, you do not need to install this solver.
-Methods default to [CBC](https://projects.coin-or.org/Cbc), an open source solver.
-You can install this solver (`coin-or-cbc`) along with your other requirements when creating the environment: `mamba create -n genet -c conda-forge -c city-modelling-lab coin-or-cbc --file requirements/base.txt --file requirements/dev.txt`,
-or install it after the fact `mamba install -n genet coin-or-cbc`
+```
+mike deploy develop
+mike serve
+```
 
-Another good open source choice is [GLPK](https://www.gnu.org/software/glpk/).
-The solver you use needs to support MILP - mixed integer linear programming.
-
-## Developing GeNet
-
-We welcome community contributions to GeNet; please see our [guide to contributing](CONTRIBUTING.md) and our [community code of conduct](CODE_OF_CONDUCT.md).
-If you are making changes to the codebase, you should use the tools described below to verify that the code still works.
-All of the following commands assume you are in the project's root directory.
-
-### Tests
-To run unit tests within genet python environment (including testing example notebooks):
-
-    pytest
-
-and within a docker container:
-
-    docker run cml-genet pytest -vv
-
-In either case, for shorter test runtimes, append 'tests/' to limit to the unit tests and ignore notebook tests.
-
-### Generate a unit test code coverage report
-
-To generate an HTML coverage report at `reports/coverage/index.html`:
-
-    pytest --cov-report=html
-
-Coverage will also be tracked in pull requests.
-
-### Lint the python code
-
-    Run `pre-commit install` to install pre-commit, which will lint and format your code whenever you commit staged changes.
+Then you can view the documentation in a browser at http://localhost:8000/.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,10 @@
+# CLI Reference
+
+This page provides documentation for our command line tools.
+
+::: mkdocs-click
+    :module: genet.cli
+    :command: cli
+    :prog_name: genet
+    :style: table
+    :depth: 1

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-genet is an actively maintained and utilised project.
+GeNet is an actively maintained and utilised project.
 
 ## How to contribute
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,78 @@
+# Contributing
+
+genet is an actively maintained and utilised project.
+
+## How to contribute
+
+to report issues, request features, or exchange with our community, just follow the links below.
+
+__Is something not working?__
+
+[:material-bug: Report a bug](https://github.com/arup-group/genet/issues/new?template=BUG-REPORT.yml "Report a bug in genet by creating an issue and a reproduction"){ .md-button }
+
+__Missing information in our docs?__
+
+[:material-file-document: Report a docs issue](https://github.com/arup-group/genet/issues/new?template=DOCS.yml "Report missing information or potential inconsistencies in our documentation"){ .md-button }
+
+__Want to submit an idea?__
+
+[:material-lightbulb-on: Request a change](https://github.com/arup-group/genet/issues/new?template=FEATURE-REQUEST.yml "Propose a change or feature request or suggest an improvement"){ .md-button }
+
+__Have a question or need help?__
+
+[:material-chat-question: Ask a question](https://github.com/arup-group/genet/discussions "Ask questions on our discussion board and get in touch with our community"){ .md-button }
+
+## Developing genet
+
+To find beginner-friendly existing bugs and feature requests you may like to start out with, take a look at our [good first issues](https://github.com/arup-group/genet/contribute).
+
+### Setting up a development environment
+
+To create a development environment for genet, with all libraries required for development and quality assurance installed, it is easiest to install genet using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager, as follows:
+
+1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
+2. Open the command line (or the "miniforge prompt" in Windows).
+3. Download (a.k.a., clone) the genet repository: `git clone git@github.com:arup-group/genet.git`
+4. Change into the `genet` directory: `cd genet`
+5. Create the genet mamba environment: `mamba create -n genet -c conda-forge --file requirements/base.txt --file requirements/dev.txt`
+6. Activate the genet mamba environment: `mamba activate genet`
+7. Install the genet package into the environment, in editable mode and ignoring dependencies (we have dealt with those when creating the mamba environment): `pip install --no-deps -e .`
+
+All together:
+
+--8<-- "README.md:docs-install-dev"
+
+If installing directly with pip, you can install these libraries using the `dev` option, i.e., `pip install -e '.[dev]'`
+Either way, you should add your environment as a jupyter kernel, so the example notebooks can run in the tests: `ipython kernel install --user --name=genet`
+If you plan to make changes to the code then please make regular use of the following tools to verify the codebase while you work:
+
+- `pre-commit`: run `pre-commit install` in your command line to load inbuilt checks that will run every time you commit your changes.
+The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [PEP8 standard](https://peps.python.org/pep-0008/).
+You can also run these checks yourself at any time to ensure staged changes are clean by calling `pre-commit`.
+- `pytest` - run the unit test suite and check test coverage.
+
+!!! note
+    If you already have an environment called `genet` on your system (e.g., for a stable installation of the package), you will need to [chose a different environment name][choosing-a-different-environment-name].
+    You will then need to add this as a pytest argument when running the tests: `pytest --nbmake-kernel=[my-env-name]`.
+
+### Rapid-fire testing
+
+The following options allow you to strip down the test suite to the bare essentials:
+
+1. The test suite includes unit tests and integration tests (in the form of jupyter notebooks found in the `examples` directory).
+The integration tests can be slow, so if you want to avoid them during development, you should run `pytest tests/`.
+2. You can avoid generating coverage reports, by adding the `--no-cov` argument: `pytest --no-cov`.
+
+All together:
+
+``` shell
+pytest tests/ --no-cov
+```
+
+!!! note
+    If you are debugging failing tests using the `--pdb` flag, tests will only run on one thread instead of the default (which is the maximum number of threads your machine has available).
+    This will slow down your tests, so do not use `--pdb` unless you are actively debugging.
+
+## Submitting changes
+
+--8<-- "CONTRIBUTING.md:docs"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,52 @@
+
+# Using GeNet as a Docker image
+
+If you have [installed GeNet as a Docker image](installation.md#using-docker), you can follow the steps here to run the GeNet CLI and to run your own scripts.
+
+## Using the cli inside a container
+
+Use `docker run cml-genet genet ...` to run the command line scripts within the Docker image, e.g.:
+
+```shell
+docker run cml-genet genet simplify-network --network /path/to/network.xml [...]
+```
+
+!!! note
+    You will reference data outside the docker container as inputs, the docker command will need the path to data
+    mounted and be referenced according to the alias given, e.g.
+
+    ```shell
+    docker run -v /local/path/:/mnt/ cml-genet genet simplify-network --network /mnt/network.xml [...]
+    ```
+
+    If the input network file lives at `/local/path/network.xml`.
+
+A full list of the available command line scripts is given on our [CLI page](api/cli.md).
+You can also get a list of options directly from the image:
+
+```shell
+docker run cml-genet genet --help
+```
+
+to show the list of available commands, and e.g.
+
+```shell
+docker run cml-genet genet simplify-network --help
+```
+
+to show description of the command and parameters.
+
+## Running custom script inside a container
+
+Say you write a script `/local/path/my_genet_scripts/script.py` and you want to run it inside a docker container.
+You will need to mount the local path to the container for the script to be found and use the generic `python`
+as part of your command:
+
+```shell
+docker run -v /local/path/:/mnt/ cml-genet python /mnt/my_genet_scripts/script.py
+```
+
+!!! note
+    If you reference data inside your script, or pass them as arguments to the script,
+    they need to reference the aliased path inside the container.
+    Here: `/mnt/`, rather than the path `/local/path/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+--8<-- "README.md:docs"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,73 @@
+
+# Installation
+
+## Using Docker
+
+If you want to avoid Python environments, you can use a Docker image to run GeNet.
+To build the image:
+
+--8<-- "README.md:docs-install-docker"
+
+Instructions for running GeNet from within the Docker image can be found [here](docker.md).
+
+## Setting up a user environment
+
+As a `genet` user, it is easiest to install using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager, as follows:
+
+1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
+2. Open the command line (or the "miniforge prompt" in Windows).
+3. mamba create -n genet -c conda-forge -c city-modelling-lab genet
+4. Activate the genet mamba environment: `mamba activate genet`
+
+All together:
+
+--8<-- "README.md:docs-install-user"
+
+### Running the example notebooks
+
+If you have followed the non-developer installation instructions above, you will need to install `jupyter` into your `genet` environment to run the [example notebooks](https://github.com/arup-group/genet/tree/main/examples):
+
+``` shell
+mamba install -n genet jupyter
+```
+
+With Jupyter installed, it's easiest to then add the environment as a jupyter kernel:
+
+``` shell
+mamba activate genet
+ipython kernel install --user --name=genet
+jupyter notebook
+```
+
+### Choosing a different environment name
+
+If you would like to use a different name to `genet` for your mamba environment, the installation becomes (where `[my-env-name]` is your preferred name for the environment):
+
+``` shell
+mamba create -n [my-env-name] -c conda-forge --file requirements/base.txt
+mamba activate [my-env-name]
+ipython kernel install --user --name=[my-env-name]
+```
+
+## Setting up a development environment
+
+The install instructions are slightly different to create a development environment compared to a user environment:
+
+--8<-- "README.md:docs-install-dev"
+
+For more detailed installation instructions specific to developing the genet codebase, see our [development documentation](contributing.md#setting-up-a-development-environment).
+
+## A note on the mathematical solver
+
+!!! note
+    The default CBC solver is pre-installed inside [GeNet's Docker image](#using-docker), which can save you some installation effort.
+
+To use methods which snap public transit to the graph, GeNet uses a mathematical solver.
+If you won't be using such functionality, you do not need to install this solver.
+Methods default to [CBC](https://projects.coin-or.org/Cbc), an open source solver.
+On Non-Windows devices, you can install this solver (`coin-or-cbc`) along with your other requirements when creating the environment: `mamba create -n genet -c conda-forge -c city-modelling-lab coin-or-cbc --file requirements/base.txt`,
+or install it after the fact `mamba install -n genet coin-or-cbc`
+
+Any solver [supported by Pyomo](https://pyomo.readthedocs.io/en/stable/solving_pyomo_models.html#supported-solvers) can be used.
+Another good open source choice is [GLPK](https://www.gnu.org/software/glpk/).
+The solver you use needs to support MILP - mixed integer linear programming.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,16 @@
+<!-- Directory to customise the mkdocs "material" theme. See [here](https://squidfunk.github.io/mkdocs-material/customization) for more detail. -->
+<!--Add download button to all pages built from jupyter notebooks-->
+
+
+{% extends "base.html" %}
+
+{% block content %}
+{% if page.nb_url %}
+<a href="{{ page.nb_url }}" title="Download Notebook" class="md-content__button md-icon">
+    {% include ".icons/material/download.svg" %}
+</a>
+{% endif %}
+
+{{ super() }}
+{% endblock content %}
+

--- a/docs/static/extras.css
+++ b/docs/static/extras.css
@@ -1,0 +1,10 @@
+/* API indentation. */
+div.doc-contents:not(.first) {
+  padding-left: 25px;
+  border-left: 4px solid rgba(230, 230, 230);
+}
+
+/* Allow tables to be horizontally scrollable. */
+.md-typeset__scrollwrap {
+  overflow-x: auto;
+}

--- a/docs/static/hooks.py
+++ b/docs/static/hooks.py
@@ -1,0 +1,152 @@
+import tempfile
+from pathlib import Path
+
+import mkdocs.plugins
+from mkdocs.structure.files import File
+
+TEMPDIR = tempfile.TemporaryDirectory()
+# Add to this list if you want to ignore any other source files from the documentation API reference
+API_FILES_TO_IGNORE = ["cli.py"]
+
+
+# Bump priority to ensure files are moved before jupyter notebook conversion takes place
+@mkdocs.plugins.event_priority(50)
+def on_files(files: list, config: dict, **kwargs):
+    """Link (1) top-level files to mkdocs files and (2) generate the python API documentation."""
+    for file in sorted(Path("./examples").glob("*.ipynb")):
+        files.append(_new_file(file, config))
+        nav_list = _get_nav_list(config["nav"], "Examples")
+        nav_list.append(file.as_posix())
+    for file in Path("./resources").glob("**/*.*"):
+        files.append(_new_file(file, config))
+    files.append(_new_file("./CHANGELOG.md", config))
+
+    api_nav = _api_gen(files, config)
+    _update_nav(api_nav, config)
+
+    return files
+
+
+def _new_file(path: Path, config: str, src_dir: str = ".") -> File:
+    """Link a file out in the wilderness to a filename in the documentation directory hierarchy.
+
+    Args:
+        path (Path):
+            Path (relative to "src_dir") to file that you want to bring into the documentation directory.
+            In the documentation directory, this same path with apply (e.g., `[src_dir]/path/to/file.md` will become `[docs_dir]/path/to/file.md`)
+        config (str): mkdocs config dictionary.
+        src_dir (str, optional):
+            Path in which to find the file you want to bring into the docs directory. Defaults to ".".
+
+    Returns:
+        File: mkdocs object that links your file to the docs directory, ready to be added to the mkdocs file list.
+    """
+    return File(
+        path=path,
+        src_dir=src_dir,
+        dest_dir=config["site_dir"],
+        use_directory_urls=config["use_directory_urls"],
+    )
+
+
+def _api_gen(files: list, config: dict) -> dict:
+    """Project Python API generator
+
+    Args:
+        files (list): mkdocs file list.
+        config (dict): mkdocs config dictionary.
+
+    Returns:
+        dict: Python API navigation tree, to add into the mkdocs `nav` tree.
+    """
+    source_dir = Path(config["watch"][0])
+    source_file = source_dir.parts[-1]
+    api_nav: dict = {"top_level": []}
+    for filepath in sorted(source_dir.rglob("[!_]*.py")):
+        rel_filepath = filepath.relative_to(source_dir)
+        if rel_filepath.as_posix() in API_FILES_TO_IGNORE:
+            continue
+        file = _py_to_md(source_file / rel_filepath, api_nav, config)
+        files.append(file)
+    return api_nav
+
+
+def _py_to_md(filepath: Path, api_nav: dict, config: dict) -> File:
+    """Create a markdown file for the API documentation for a given python file in the package source directory.
+
+    Markdown files are stored in a temporary directory, which will be cleaned after mkdocs has finished building the docs.
+
+    Args:
+        filepath (Path): Path to python file relative to the package source code directory.
+        api_nav (dict): Nested dictionary to fill with mkdocs navigation entries.
+        config (Config): mkdocs config dictionary.
+    Returns:
+        File: mkdocs object that links the temp file to the docs directory, ready to be added to the mkdocs file list.
+    """
+    module_parts = filepath.with_suffix("").parts
+
+    module_name = ".".join(module_parts)
+
+    api_file = "reference" / filepath.with_suffix(".md")
+    api_full_filepath = Path(TEMPDIR.name) / api_file
+    api_full_filepath.parent.mkdir(exist_ok=True, parents=True)
+    api_full_filepath.write_text(f"::: {module_name}")
+
+    nav_component = {module_name: api_file.as_posix()}
+    if len(module_parts) > 2:  # i.e., in a nested directory
+        parent_module = ".".join(module_parts[:2])
+        if parent_module not in api_nav:
+            api_nav[parent_module] = [nav_component]
+        else:
+            api_nav[parent_module].append(nav_component)
+    else:
+        api_nav["top_level"].append(nav_component)
+    return _new_file(api_file, config, TEMPDIR.name)
+
+
+def _update_nav(api_nav: dict, config: dict) -> None:
+    """Update mkdocs navigation tree with the Python API sub-tree.
+
+    Mkdocs navigation is composed of lists of dictionaries.
+    Lists nesting defines navigation nesting, dictionary keys are the page names, and values are the pointers to markdown files.
+
+    Args:
+        api_nav (dict): Python API navigation tree.
+        config (dict): mkdocs config dictionary (in which `nav` can be found).
+    """
+
+    api_reference_nav = {
+        "Python API": [*api_nav.pop("top_level"), *[{k: v} for k, v in api_nav.items()]]
+    }
+    nav_list = _get_nav_list(config["nav"], "Reference")
+    nav_list.append(api_reference_nav)
+
+
+def _get_nav_list(nav: list[dict | str], ref: str) -> list:
+    """Get navigation entry sub-page list.
+    Navigation list entries can be dictionaries or strings.
+    Sub-list entries can then also be dictionaries or strings. E.g.,
+
+    ```python
+    [{"Page Title": ["sub-page-1", {"Sub-Page-2 Title": "sub-page-2"}, ...], ...}]
+    ```
+
+    Args:
+        nav (list[dict  |  str]): MKdocs `nav` config entry.
+        ref (str): Page title reference to return the sub-list of.
+
+    Returns:
+        list: Nav sub-list linked to `ref`.
+    """
+    nav_ref = [idx for idx in nav if isinstance(idx, dict) and set(idx.keys()) == {ref}][0]
+    return nav_ref[ref]
+
+
+@mkdocs.plugins.event_priority(-100)
+def on_post_build(**kwargs):
+    """After mkdocs has finished building the docs, remove the temporary directory of markdown files.
+
+    Args:
+        config (Config): mkdocs config dictionary (unused).
+    """
+    TEMPDIR.cleanup()

--- a/genet/core.py
+++ b/genet/core.py
@@ -5,15 +5,17 @@ import os
 import traceback
 import uuid
 from copy import deepcopy
-from typing import Dict, List, Union
+from typing import Any, Callable, Iterator, Literal, Optional, Union
 
 import geopandas as gpd
 import networkx as nx
 import numpy as np
 import pandas as pd
+from keplergl import KeplerGl
 from pyproj import Transformer
 from s2sphere import CellId
 from shapely.geometry import LineString, Point
+from shapely.geometry.base import BaseGeometry
 
 import genet.auxiliary_files as auxiliary_files
 import genet.exceptions as exceptions
@@ -39,7 +41,14 @@ logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.INFO)
 
 
 class Network:
-    def __init__(self, epsg, **kwargs):
+    def __init__(self, epsg: str, **kwargs):
+        """GeNet network class.
+
+        Args:
+            epsg (str): Coordinate reference system, e.g. "EPSG:4326".
+
+        Keyword Args: will be added as attributes of the class.
+        """
         self.epsg = epsg
         self.transformer = Transformer.from_crs(epsg, "epsg:4326", always_xy=True)
         self.graph = nx.MultiDiGraph(name="Network graph", crs=epsg)
@@ -63,10 +72,10 @@ class Network:
         return self.info()
 
     def add_additional_attributes(self, attribs: dict):
-        """
-        adds attributes defined by keys of the attribs dictionary with values of the corresponding values
-        :param attribs: the additional attributes {attribute_name: attribute_value}
-        :return:
+        """Adds attributes defined by keys of the attribs dictionary with values of the corresponding values.
+
+        Args:
+            attribs (dict): The additional attributes {attribute_name: attribute_value}
         """
         for k, v in attribs.items():
             if k not in self.__dict__:
@@ -80,13 +89,17 @@ class Network:
     def has_attrib(self, attrib_name):
         return attrib_name in self.__dict__
 
-    def add(self, other):
-        """
-        This lets you add on `other` genet.Network to the network this method is called on.
-        This is deliberately not a magic function to discourage `new_network = network_1 + network_2` (and memory
-        goes out the window)
-        :param other:
-        :return:
+    def add(self, other: "Network"):
+        """This lets you add on `other` genet.Network to the network this method is called on.
+
+        This is deliberately not a magic function to discourage `new_network = network_1 + network_2`,
+        where memory goes out the window.
+
+        Args:
+            other (Network): Network to add.
+
+        Raises:
+            RuntimeError: Cannot add simplified and non-simplified networks together.
         """
         if self.is_simplified() != other.is_simplified():
             raise RuntimeError("You cannot add simplified and non-simplified networks together")
@@ -121,15 +134,21 @@ class Network:
     def info(self):
         return f"Graph info: {str(self.graph)} \nSchedule info: {self.schedule.info()}"
 
-    def plot(self, output_dir="", data=False):
-        """
-        Plots the network graph and schedule on kepler map.
-        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install
-        :param output_dir: output directory for the image, if passed, will save plot to html
-        :param data: Defaults to False, only the geometry and ID will be visible.
-            True will visualise all data on the map (not suitable for large networks)
-            A set of keys e.g. {'freespeed', 'capacity'}
-        :return:
+    def plot(self, output_dir: str = "", data: Union[bool, set] = False) -> KeplerGl:
+        """Plots the network graph and schedule on kepler map.
+
+        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install.
+
+        Args:
+            output_dir (str, optional): Output directory for the image, if passed, will save plot to html. Defaults to "".
+            data (bool | set, optional):
+                If False, only the geometry and ID will be visible.
+                If True, all data will be visible on the map (not suitable for large networks)
+                If a set of keys, e.g. {'freespeed', 'capacity'}, only that data will be visible.
+                Defaults to False.
+
+        Returns:
+            KeplerGl: Kepler plot object.
         """
         if not self.schedule:
             logging.warning(
@@ -159,15 +178,21 @@ class Network:
             m.save_to_html(file_name=os.path.join(output_dir, "network_with_pt_routes.html"))
         return m
 
-    def plot_graph(self, output_dir="", data=False):
-        """
-        Plots the network graph only on kepler map.
-        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install
-        :param output_dir: output directory for the image, if passed, will save plot to html
-        :param data: Defaults to False, only the geometry and ID will be visible.
-            True will visualise all data on the map (not suitable for large networks)
-            A set of keys e.g. {'freespeed', 'capacity'}
-        :return:
+    def plot_graph(self, output_dir: str = "", data: Union[bool, set] = False) -> KeplerGl:
+        """Plots the network graph only on kepler map.
+
+        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install.
+
+        Args:
+            output_dir (str, optional): Output directory for the image, if passed, will save plot to html. Defaults to "".
+            data (bool | set, optional):
+                If False, only the geometry and ID will be visible.
+                If True, all data will be visible on the map (not suitable for large networks)
+                If a set of keys, e.g. {'freespeed', 'capacity'}, only that data will be visible.
+                Defaults to False.
+
+        Returns:
+            KeplerGl:  Kepler plot object.
         """
         network_links = self.to_geodataframe()["links"]
 
@@ -185,15 +210,21 @@ class Network:
             m.save_to_html(file_name=os.path.join(output_dir, "network_graph.html"))
         return m
 
-    def plot_schedule(self, output_dir="", data=False):
-        """
-        Plots original stop connections in the network's schedule over the network graph on kepler map.
-        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install
-        :param output_dir: output directory for the image, if passed, will save plot to html
-        :param data: Defaults to False, only the geometry and ID will be visible.
-            True will visualise all data on the map (not suitable for large networks)
-            A set of keys e.g. {'freespeed', 'capacity'}
-        :return:
+    def plot_schedule(self, output_dir: str = "", data: Union[bool, set] = False) -> KeplerGl:
+        """Plots original stop connections in the network's schedule over the network graph on kepler map.
+
+        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install.
+
+        Args:
+            output_dir (str, optional): Output directory for the image, if passed, will save plot to html. Defaults to "".
+            data (bool | set, optional):
+                If False, only the geometry and ID will be visible.
+                If True, all data will be visible on the map (not suitable for large networks)
+                If a set of keys, e.g. {'freespeed', 'capacity'}, only that data will be visible.
+                Defaults to False.
+
+        Returns:
+            KeplerGl:  Kepler plot object.
         """
         network_links = self.to_geodataframe()["links"]
         schedule_gdf = self.schedule.to_geodataframe()
@@ -222,12 +253,12 @@ class Network:
             m.save_to_html(file_name=os.path.join(output_dir, "network_and_schedule.html"))
         return m
 
-    def reproject(self, new_epsg, processes=1):
-        """
-        Changes projection of the network to new_epsg
-        :param new_epsg: 'epsg:1234'
-        :param processes: max number of process to split computation across
-        :return:
+    def reproject(self, new_epsg: str, processes: int = 1):
+        """Changes projection of the network to `new_epsg`.
+
+        Args:
+            new_epsg (str): New network projection, e.g., 'epsg:1234'.
+            processes (int, optional): max number of process to split computation across. Defaults to 1.
         """
         # reproject nodes
         nodes_attribs = dict(self.nodes())
@@ -255,21 +286,33 @@ class Network:
         self.initiate_crs_transformer(new_epsg)
         self.graph.graph["crs"] = self.epsg
 
-    def initiate_crs_transformer(self, epsg):
+    def initiate_crs_transformer(self, epsg: str):
+        """Set the networks projection transformer to `epsg`.
+
+        Args:
+            epsg (str): Projection, e.g., 'epsg:1234'.
+        """
         self.epsg = epsg
         if epsg != "epsg:4326":
             self.transformer = Transformer.from_crs(epsg, "epsg:4326", always_xy=True)
         else:
             self.transformer = None
 
-    def simplify(self, no_processes=1, keep_loops=False):
-        """
-        Simplifies network graph, retaining only nodes that are junctions
-        :param no_processes: Number of processes to split some computation across. The method is pretty fast though
-            and 1 process is often preferable --- there is overhead for splitting and joining the data.
-        :param keep_loops: bool, defaults to False. Simplification often leads to self-loops, these will be removed
-            unless keep_loops=True
-        :return: None, updates Network object
+    def simplify(self, no_processes: int = 1, keep_loops: bool = False):
+        """Simplifies network graph in-place, retaining only nodes that are junctions.
+
+        Args:
+            no_processes (int, optional):
+                Number of processes to split some computation across.
+                The method is pretty fast though and 1 process is often preferable --- there is overhead for splitting and joining the data.
+                Defaults to 1.
+            keep_loops (bool, optional):
+                Simplification often leads to self-loops.
+                These will be removed unless keep_loops=`True`.
+                Defaults to False.
+
+        Raises:
+            RuntimeError: Can only simply the network once.
         """
         if self.is_simplified():
             raise RuntimeError(
@@ -314,176 +357,206 @@ class Network:
             return self.attributes["simplified"] in {"true", "True", True}
         return False
 
-    def node_attribute_summary(self, data=False):
-        """
-        Parses through data stored on nodes and gives a summary tree of the data stored on the nodes.
-        If data is True, shows also up to 5 unique values stored under such keys.
-        :param data: bool, False by default
-        :return:
+    def node_attribute_summary(self, data: bool = False):
+        """Parses through data stored on nodes and gives a summary tree of the data stored on the nodes.
+
+        Args:
+            data (bool, optional):
+                If True, shows also up to 5 unique values stored under such keys.
+                Defaults to False.
         """
         root = graph_operations.get_attribute_schema(self.nodes(), data=data)
         graph_operations.render_tree(root, data)
 
-    def node_attribute_data_under_key(self, key):
-        """
-        Generates a pandas.Series object indexed by node ids, with data stored on the nodes under `key`
-        :param key: either a string e.g. 'x', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :return: pandas.Series
+    def node_attribute_data_under_key(self, key: Union[str, dict]) -> pd.Series:
+        """Generates a pandas.Series object indexed by node ids, with data stored on the nodes under `key`.
+
+        Args:
+            key (Union[str, dict]):
+                Either a string e.g. 'x', or if accessing nested information, a dictionary e.g. {'attributes': {'osm:way:name': 'text'}}.
+
+        Returns:
+            pd.Series: Node attribute data as a pandas Series.
         """
         data = graph_operations.get_attribute_data_under_key(self.nodes(), key)
         return pd.Series(data, dtype=pd_helpers.get_pandas_dtype(data))
 
-    def node_attribute_data_under_keys(self, keys: Union[list, set], index_name=None):
-        """
-        Generates a pandas.DataFrame object indexed by link ids, with data stored on the nodes under `key`
-        :param keys: list of either a string e.g. 'x', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
+    def node_attribute_data_under_keys(
+        self, keys: Union[list, set], index_name: Optional[str] = None
+    ) -> pd.DataFrame:
+        """Generates a pandas.DataFrame object indexed by node ids, with columns containing data stored on the nodes under each of `keys`.
+
+        Args:
+            keys (Union[list, set]): An iterable of either a string e.g. 'x', or if accessing nested information, a dictionary e.g. {'attributes': {'osm:way:name': 'text'}}.
+            index_name (Optional[str], optional): If given, is used to set the dataframe index name. Defaults to None.
+
+        Returns:
+            pd.DataFrame: Node attributes.
         """
         return graph_operations.build_attribute_dataframe(
             self.nodes(), keys=keys, index_name=index_name
         )
 
-    def link_attribute_summary(self, data=False):
-        """
-        Parses through data stored on links and gives a summary tree of the data stored on the links.
-        If data is True, shows also up to 5 unique values stored under such keys.
-        :param data: bool, False by default
-        :return:
+    def link_attribute_summary(self, data: bool = False):
+        """Parses through data stored on links and prints a summary tree of the data stored on the links.
+
+        Args:
+            data (bool, optional): If True, shows also up to 5 unique values stored under such keys. Defaults to False.
         """
         root = graph_operations.get_attribute_schema(self.links(), data=data)
         graph_operations.render_tree(root, data)
 
-    def link_attribute_data_under_key(self, key: Union[str, dict]):
-        """
-        Generates a pandas.Series object indexed by link ids, with data stored on the links under `key`
-        :param key: either a string e.g. 'modes', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :return: pandas.Series
+    def link_attribute_data_under_key(self, key: Union[str, dict]) -> pd.Series:
+        """Generates a pandas.Series object indexed by link ids, with data stored on the nodes under `key`.
+
+        Args:
+            key (Union[str, dict]):
+                Either a string e.g. 'x', or if accessing nested information, a dictionary e.g. {'attributes': {'osm:way:name': 'text'}}.
+
+        Returns:
+            pd.Series: Link ID attribute data as a pandas Series.
         """
         return pd.Series(graph_operations.get_attribute_data_under_key(self.links(), key))
 
-    def link_attribute_data_under_keys(self, keys: Union[list, set], index_name=None):
-        """
-        Generates a pandas.DataFrame object indexed by link ids, with data stored on the links under `key`
-        :param keys: list of either a string e.g. 'modes', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
+    def link_attribute_data_under_keys(
+        self, keys: Union[list, set], index_name: Optional[str] = None
+    ) -> pd.DataFrame:
+        """Generates a pandas.DataFrame object indexed by link ids, with columns containing data stored on the links under each of `keys`.
+
+        Args:
+            keys (Union[list, set]): An iterable of either a string e.g. 'x', or if accessing nested information, a dictionary e.g. {'attributes': {'osm:way:name': 'text'}}.
+            index_name (Optional[str], optional): If given, is used to set the dataframe index name. Defaults to None.
+
+        Returns:
+            pd.DataFrame: Link ID attributes.
         """
         return graph_operations.build_attribute_dataframe(
             self.links(), keys=keys, index_name=index_name
         )
 
     def extract_nodes_on_node_attributes(
-        self, conditions: Union[list, dict], how=any, mixed_dtypes=True
-    ):
-        """
-        Extracts graph node IDs based on values of attributes saved on the nodes. Fails silently,
-        assumes not all nodes have all of the attributes. In the case were the attributes stored are
-        a list or set, like in the case of a simplified network (there will be a mix of objects that are sets and not)
-        an intersection of values satisfying condition(s) is considered in case of iterable value, if not empty, it is
-        deemed successful by default. To disable this behaviour set mixed_dtypes to False.
-        :param conditions: {'attribute_key': 'target_value'} or nested
-        {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}}, where 'target_value' could be
+        self, conditions: Union[list, dict], how: Callable = any, mixed_dtypes: bool = True
+    ) -> list[str]:
+        """Extracts graph node IDs based on values of attributes saved on the nodes.
 
-            - single value, string, int, float, where the edge_data[key] == value
+        Fails silently, assumes not all nodes have all of the attributes.
+
+        In the case where the attributes stored are a list or set, like in the case of a simplified network (there will be a mix of objects that are sets and not), an intersection of values satisfying condition(s) is considered.
+        It is deemed successful by default.
+        To disable this behaviour set `mixed_dtypes` to False.
+
+        Args:
+            conditions (Union[list, dict]):
+                {'attribute_key': 'target_value'} or nested {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}},
+                where 'target_value' could be:
+
+                - single value, string, int, float, where the edge_data[key] == value
                 (if mixed_dtypes==True and in case of set/list edge_data[key], value is in edge_data[key])
 
-            - list or set of single values as above, where edge_data[key] in [value1, value2]
+                - list or set of single values as above, where edge_data[key] in [value1, value2]
                 (if mixed_dtypes==True and in case of set/list edge_data[key],
                 set(edge_data[key]) & set([value1, value2]) is non-empty)
 
-            - for int or float values, two-tuple bound (lower_bound, upper_bound) where
-              lower_bound <= edge_data[key] <= upper_bound
+                - for int or float values, two-tuple bound (lower_bound, upper_bound) where
+                lower_bound <= edge_data[key] <= upper_bound
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] satisfies lower_bound <= item <= upper_bound)
 
-            - function that returns a boolean given the value e.g.
-
-            def below_exclusive_upper_bound(value):
-                return value < 100
-
+                - function that returns a boolean given the value e.g.
+                ```python
+                def below_exclusive_upper_bound(value):
+                    return value < 100
+                ```
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] returns True after applying function)
 
-        :param how : {all, any}, default any
+            how (Callable, optional):
+                The level of rigour used to match conditions. Defaults to any.
+                - all: means all conditions need to be met
+                - any: means at least one condition needs to be met
 
-        The level of rigour used to match conditions
+            mixed_dtypes (bool, optional):
+                If True, will consider the intersection of single values or lists of values in queried dictionary keys, e.g. as in simplified networks.
+                Defaults to True.
 
-            * all: means all conditions need to be met
-            * any: means at least one condition needs to be met
-
-        :param mixed_dtypes: True by default, used if values under dictionary keys queried are single values or lists of
-        values e.g. as in simplified networks.
-        :return: list of node ids in the network satisfying conditions
+        Returns:
+            list[str]: Graph node IDs where attribute values match `conditions`.
         """
         return graph_operations.extract_on_attributes(
             self.nodes(), conditions=conditions, how=how, mixed_dtypes=mixed_dtypes
         )
 
     def extract_links_on_edge_attributes(
-        self, conditions: Union[list, dict], how=any, mixed_dtypes=True
-    ):
-        """
-        Extracts graph link IDs based on values of attributes saved on the edges. Fails silently,
-        assumes not all links have those attributes. In the case were the attributes stored are
-        a list or set, like in the case of a simplified network (there will be a mix of objects that are sets and not)
-        an intersection of values satisfying condition(s) is considered in case of iterable value, if not empty, it is
-        deemed successful by default. To disable this behaviour set mixed_dtypes to False.
-        :param conditions: {'attribute_key': 'target_value'} or nested
-        {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}}, where 'target_value' could be
+        self, conditions: Union[list, dict], how: Callable = any, mixed_dtypes: bool = True
+    ) -> list[str]:
+        """Extracts graph link IDs based on values of attributes saved on the links.
 
-            - single value, string, int, float, where the edge_data[key] == value
+        Fails silently, assumes not all links have all of the attributes.
+
+        In the case where the attributes stored are a list or set, like in the case of a simplified network (there will be a mix of objects that are sets and not), an intersection of values satisfying condition(s) is considered.
+        It is deemed successful by default.
+        To disable this behaviour set `mixed_dtypes` to False.
+
+        Args:
+            conditions (Union[list, dict]):
+                {'attribute_key': 'target_value'} or nested {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}},
+                where 'target_value' could be:
+
+                - single value, string, int, float, where the edge_data[key] == value
                 (if mixed_dtypes==True and in case of set/list edge_data[key], value is in edge_data[key])
 
-            - list or set of single values as above, where edge_data[key] in [value1, value2]
+                - list or set of single values as above, where edge_data[key] in [value1, value2]
                 (if mixed_dtypes==True and in case of set/list edge_data[key],
                 set(edge_data[key]) & set([value1, value2]) is non-empty)
 
-            - for int or float values, two-tuple bound (lower_bound, upper_bound) where
-              lower_bound <= edge_data[key] <= upper_bound
+                - for int or float values, two-tuple bound (lower_bound, upper_bound) where
+                lower_bound <= edge_data[key] <= upper_bound
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] satisfies lower_bound <= item <= upper_bound)
 
-            - function that returns a boolean given the value e.g.
-
-            def below_exclusive_upper_bound(value):
-                return value < 100
-
+                - function that returns a boolean given the value e.g.
+                ```python
+                def below_exclusive_upper_bound(value):
+                    return value < 100
+                ```
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] returns True after applying function)
 
-        :param how : {all, any}, default any
+            how (Callable, optional):
+                The level of rigour used to match conditions. Defaults to any.
+                - all: means all conditions need to be met
+                - any: means at least one condition needs to be met
 
-        The level of rigour used to match conditions
+            mixed_dtypes (bool, optional):
+                If True, will consider the intersection of single values or lists of values in queried dictionary keys, e.g. as in simplified networks.
+                Defaults to True.
 
-            * all: means all conditions need to be met
-            * any: means at least one condition needs to be met
-
-        :param mixed_dtypes: True by default, used if values under dictionary keys queried are single values or lists of
-        values e.g. as in simplified networks.
-        :return: list of link ids in the network satisfying conditions
+        Returns:
+            list[str]: Graph link IDs where attribute values match `conditions`.
         """
         return graph_operations.extract_on_attributes(
             self.links(), conditions=conditions, how=how, mixed_dtypes=mixed_dtypes
         )
 
-    def links_on_modal_condition(self, modes: Union[str, list]):
-        """
-        Finds link IDs with modes or singular mode given in `modes`
-        :param modes: string mode e.g. 'car' or a list of such modes e.g. ['car', 'walk']
-        :return: list of link IDs
+    def links_on_modal_condition(self, modes: Union[str, list]) -> list[str]:
+        """Finds link IDs with modes or singular mode given in `modes`.
+
+        Args:
+            modes (Union[str, list]): string mode e.g. 'car' or a list of such modes e.g. ['car', 'walk'].
+
+        Returns:
+            list[str]: list of link IDs.
         """
         return self.extract_links_on_edge_attributes(conditions={"modes": modes}, mixed_dtypes=True)
 
-    def nodes_on_modal_condition(self, modes: Union[str, list]):
-        """
-        Finds node IDs with modes or singular mode given in `modes`
-        :param modes: string mode e.g. 'car' or a list of such modes e.g. ['car', 'walk']
-        :return: list of link IDs
+    def nodes_on_modal_condition(self, modes: Union[str, list]) -> list[str]:
+        """Finds node IDs with modes or singular mode given in `modes`.
+
+        Args:
+            modes (Union[str, list]): string mode e.g. 'car' or a list of such modes e.g. ['car', 'walk'].
+
+        Returns:
+            list[str]: list of node IDs.
         """
         links = self.links_on_modal_condition(modes)
         nodes = {self.link(link)["from"] for link in links} | {
@@ -491,19 +564,22 @@ class Network:
         }
         return list(nodes)
 
-    def modal_subgraph(self, modes: Union[str, set, list]):
+    def modal_subgraph(self, modes: Union[str, set, list]) -> nx.MultiDiGraph:
         return self.subgraph_on_link_conditions(conditions={"modes": modes}, mixed_dtypes=True)
 
-    def nodes_on_spatial_condition(self, region_input):
-        """
-        Returns node IDs which intersect region_input
-        :param region_input:
-            - path to a geojson file, can have multiple features
-            - string with comma separated hex tokens of Google's S2 geometry, a region can be covered with cells and
-             the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/
-             e.g. '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'
-            - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects
-        :return: node IDs
+    def nodes_on_spatial_condition(self, region_input: Union[str, BaseGeometry]) -> list[str]:
+        """Returns node IDs which intersect `region_input`.
+
+        Args:
+            region_input (Union[str, BaseGeometry]):
+                - path to a geojson file, can have multiple features.
+                - string with comma separated hex tokens of Google's S2 geometry.
+                A region can be covered with cells and the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/.
+                E.g., '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'.
+                - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects.
+
+        Returns:
+            list[str]: Node IDs
         """
         if not isinstance(region_input, str):
             # assumed to be a shapely.geometry input
@@ -518,20 +594,26 @@ class Network:
             # is assumed to be hex
             return self._find_node_ids_on_s2_geometry(region_input)
 
-    def links_on_spatial_condition(self, region_input, how="intersect"):
-        """
-        Returns link IDs which intersect region_input
-        :param region_input:
-            - path to a geojson file, can have multiple features
-            - string with comma separated hex tokens of Google's S2 geometry, a region can be covered with cells and
-             the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/
-             e.g. '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'
-            - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects
-        :param how:
-            - 'intersect' default, will return IDs of the Services whose at least one Stop intersects the
-            region_input
-            - 'within' will return IDs of the Services whose all of the Stops are contained within the region_input
-        :return: link IDs
+    def links_on_spatial_condition(
+        self,
+        region_input: Union[str, BaseGeometry],
+        how: Literal["intersect", "within"] = "intersect",
+    ) -> list[str]:
+        """Returns link IDs which intersect `region_input`.
+
+        Args:
+            region_input (Union[str, BaseGeometry]):
+                - path to a geojson file, can have multiple features.
+                - string with comma separated hex tokens of Google's S2 geometry.
+                A region can be covered with cells and the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/.
+                E.g., '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'.
+                - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects.
+            how (Literal[intersect, within], optional):
+                Defaults to "intersect".
+                - 'intersect' will return IDs of the Services whose at least one Stop intersects the `region_input`.
+                - 'within' will return IDs of the Services whose all of the Stops are contained within the `region_input`.
+        Returns:
+            list[str]: Link IDs.
         """
         gdf = self.to_geodataframe()["links"].to_crs("epsg:4326")
         if not isinstance(region_input, str):
@@ -546,20 +628,26 @@ class Network:
     def subnetwork(
         self,
         links: Union[list, set],
-        services: Union[list, set] = None,
-        strongly_connected_modes: Union[list, set] = None,
+        services: Optional[Union[list, set]] = None,
+        strongly_connected_modes: Optional[Union[list, set]] = None,
         n_connected_components: int = 1,
-    ):
-        """
-        Subset a Network object using a collection of link IDs and (optionally) service IDs
-        :param links: Link IDs to be retained in the new Network
-        :param services: optional, collection of service IDs in the Schedule for subsetting.
-        :param strongly_connected_modes: modes in the network that need to be strongly connected. For MATSim those
-            are modes that agents are allowed to route on. Defaults to {'car', 'walk', 'bike'}
-        :param n_connected_components: number of expected strongly connected components for
-            `the strongly_connected_modes`. Defaults to 1, as that is what MATSim expects. Other number may be used
-            if disconnected islands are expected, and then connected up using the `connect_components` method.
-        :return: A new Network object that is a subset of the original
+    ) -> "Network":
+        """Subset a Network object using a collection of link IDs and (optionally) service IDs.
+
+        Args:
+            links (Union[list, set]): Link IDs to be retained in the new Network.
+            services (Optional[Union[list, set]], optional): Collection of service IDs in the Schedule for subsetting. Defaults to None.
+            strongly_connected_modes (Optional[Union[list, set]], optional):
+                Modes in the network that need to be strongly connected.
+                For MATSim those  are modes that agents are allowed to route on. Defaults to {'car', 'walk', 'bike'}.
+                Defaults to None.
+            n_connected_components (int, optional):
+                Number of expected strongly connected components for `the strongly_connected_modes`.
+                Defaults to 1, as that is what MATSim expects.
+                Other number may be used if disconnected islands are expected, and then connected up using the `connect_components` method.
+
+        Returns:
+            Network: A new Network object that is a subset of the original
         """
         logging.info(
             "Subsetting a Network will likely result in a disconnected network graph. A cleaner will be ran "
@@ -609,29 +697,35 @@ class Network:
 
     def subnetwork_on_spatial_condition(
         self,
-        region_input,
-        how="intersect",
-        strongly_connected_modes: Union[list, set] = None,
+        region_input: Union[str, BaseGeometry],
+        how: Literal["intersect", "within"] = "intersect",
+        strongly_connected_modes: Optional[Union[list, set]] = None,
         n_connected_components: int = 1,
-    ):
-        """
-        Subset a Network object using a spatial bound
-        :param region_input:
-            - path to a geojson file, can have multiple features
-            - string with comma separated hex tokens of Google's S2 geometry, a region can be covered with cells and
-             the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/
-             e.g. '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'
-            - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects
-        :param how:
-            - 'intersect' default, will return IDs of the Services whose at least one Stop intersects the
-            region_input
-            - 'within' will return IDs of the Services whose all of the Stops are contained within the region_input
-        :param strongly_connected_modes: modes in the network that need to be strongly connected. For MATSim those
-            are modes that agents are allowed to route on. Defaults to {'car', 'walk', 'bike'}
-        :param n_connected_components: number of expected strongly connected components for
-            `the strongly_connected_modes`. Defaults to 1, as that is what MATSim expects. Other number may be used
-            if disconnected islands are expected, and then connected up using the `connect_components` method.
-        :return: A new Network object that is a subset of the original
+    ) -> "Network":
+        """Subset a Network object using a spatial bound.
+
+        Args:
+            region_input (Union[str, BaseGeometry]):
+                - path to a geojson file, can have multiple features.
+                - string with comma separated hex tokens of Google's S2 geometry.
+                A region can be covered with cells and the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/.
+                E.g., '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'.
+                - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects.
+            how (Literal[intersect, within], optional):
+                Defaults to "intersect".
+                - 'intersect' will return IDs of the Services whose at least one Stop intersects the `region_input`.
+                - 'within' will return IDs of the Services whose all of the Stops are contained within the `region_input`.
+            strongly_connected_modes (Optional[Union[list, set]], optional):
+                Modes in the network that need to be strongly connected.
+                For MATSim those  are modes that agents are allowed to route on. Defaults to {'car', 'walk', 'bike'}.
+                Defaults to None.
+            n_connected_components (int, optional):
+                Number of expected strongly connected components for `the strongly_connected_modes`.
+                Defaults to 1, as that is what MATSim expects.
+                Other number may be used if disconnected islands are expected, and then connected up using the `connect_components` method.
+
+        Returns:
+            Network: A new Network object that is a subset of the original
         """
         if self.schedule:
             services_to_keep = self.schedule.services_on_spatial_condition(
@@ -649,11 +743,11 @@ class Network:
         )
 
     def remove_mode_from_links(self, links: Union[set, list], mode: Union[set, list, str]):
-        """
-        Method to remove modes from links. Deletes links which have no mode left after the process.
-        :param links: collection of link IDs to remove the mode from
-        :param mode: which mode to remove
-        :return: updates graph
+        """Method to remove modes from links in-place.
+
+        Args:
+            links (Union[set, list]): Collection of link IDs to remove the mode from.
+            mode (Union[set, list, str]): Which mode to remove.
         """
 
         def empty_modes(mode_attrib):
@@ -682,12 +776,13 @@ class Network:
         self.remove_links(no_mode_links)
 
     def retain_n_connected_subgraphs(self, n: int, mode: str):
-        """
-        Method to remove modes from link which do not belong to largest connected n components. Deletes links which
-        have no mode left after the process.
-        :param n: number of components to retain
-        :param mode: which mode to consider
-        :return: updates graph
+        """Method to remove modes in-place from link which do not belong to largest connected n components.
+
+        Deletes links which have no mode left after the process.
+
+        Args:
+            n (int): Number of components to retain.
+            mode (str): Which mode to consider.
         """
         modal_subgraph = self.modal_subgraph(mode)
         # calculate how many connected subgraphs there are
@@ -749,29 +844,44 @@ class Network:
         else:
             raise NotImplementedError("Only `intersect` and `within` options for `how` param.")
 
-    def add_node(self, node: Union[str, int], attribs: dict, silent: bool = False):
-        """
-        Adds a node.
-        :param node:
-        :param attribs: must include spatial information x,y in epsg consistent with the network,
-        or lat lon in epsg:4326
-        :param silent: whether to mute stdout logging messages
-        :return:
+    def add_node(self, node: Union[str, int], attribs: dict, silent: bool = False) -> dict:
+        """Adds a node.
+
+        Args:
+            node (Union[str, int]): Node ID to add.
+            attribs (dict):
+                Node attributes.
+                Must include spatial information x,y in epsg consistent with the network, or lat lon in "epsg:4326".
+            silent (bool, optional): Whether to mute stdout logging messages. Defaults to False.
+
+        Returns:
+            dict: If node ID clashes with existing ID, the mapping of input node ID with renamed node ID.
         """
         return self.add_nodes({node: attribs}, silent=silent)[0]
 
     def add_nodes(
         self, nodes_and_attribs: dict, silent: bool = False, ignore_change_log: bool = False
-    ):
+    ) -> tuple[dict, dict]:
+        """Adds nodes, reindexes if indices are clashing with nodes already in the network.
+
+        Args:
+            nodes_and_attribs (dict): `{index_for_node: {attribute dictionary for that node}}`.
+            silent (bool, optional): Whether to mute stdout logging messages. Defaults to False.
+            ignore_change_log (bool, optional):
+                Whether to ignore logging changes to the network in the changelog.
+                Not recommended.
+                Only used when an alternative changelog event is being produced (e.g. simplification) to reduce changelog bloat.
+                Defaults to False.
+
+        Raises:
+            RuntimeError: Must include spatial information in node attribute dictionary.
+
+        Returns:
+            tuple[dict, dict]:
+                First dict is a mapping from input node IDs to internal node IDs (IDs reindexed if there is any name clashes with existing nodes).
+                Second dict is `nodes_and_attribs` with node IDs updated according to the mapping of the first dict.
         """
-        Adds nodes, reindexes if indices are clashing with nodes already in the network
-        :param nodes_and_attribs: {index_for_node: {attribute dictionary for that node}}
-        :param silent: whether to mute stdout logging messages
-        :param ignore_change_log: whether to ignore logging changes to the network in the changelog. False by default
-        and not recommended. Only used when an alternative changelog event is being produced (e.g. simplification) to
-        reduce changelog bloat.
-        :return:
-        """
+
         # check for spatial info
         for node_id, attribs in nodes_and_attribs.items():
             keys = set(attribs.keys())
@@ -860,20 +970,28 @@ class Network:
         self,
         u: Union[str, int],
         v: Union[str, int],
-        multi_edge_idx: int = None,
-        attribs: dict = None,
+        multi_edge_idx: Optional[int] = None,
+        attribs: Optional[dict] = None,
         silent: bool = False,
-    ):
-        """
-        Adds an edge between u and v. If an edge between u and v already exists, adds an additional one. Generates
-        link id. If you already have a link id, use the method to add_link.
-        :param u: node in the graph
-        :param v: node in the graph
-        :param multi_edge_idx: you can specify which multi index to use if there are other edges between u and v.
-        Will generate new index if already used.
-        :param attribs:
-        :param silent: whether to mute stdout logging messages
-        :return:
+    ) -> str:
+        """Adds an edge between u and v.
+
+        If an edge between u and v already exists, adds an additional one.
+        Generates a new link id.
+        If you already have a link id, use the method to add_link.
+
+        Args:
+            u (Union[str, int]): node in the graph.
+            v (Union[str, int]): node in the graph.
+            multi_edge_idx (Optional[int], optional):
+                You can specify which multi index to use if there are other edges between u and v.
+                Will generate new index if already used.
+                Defaults to None.
+            attribs (Optional[dict], optional): Attributes to add to generated link. Defaults to None.
+            silent (bool, optional): Whether to mute stdout logging messages. Defaults to False.
+
+        Returns:
+            str: Generated link ID
         """
         link_id = self.generate_index_for_edge(silent=silent)
         self.add_link(link_id, u, v, multi_edge_idx, attribs, silent)
@@ -882,17 +1000,28 @@ class Network:
         return link_id
 
     def add_edges(
-        self, edges_attributes: List[dict], silent: bool = False, ignore_change_log: bool = False
-    ):
-        """
-        Adds multiple edges, generates their unique link ids
-        :param edges_attributes: List of edges, each item in list is a dictionary defining the edge attributes,
-        contains at least 'from': node_id and 'to': node_id entries,
-        :param silent: whether to mute stdout logging messages
-        :param ignore_change_log: whether to ignore logging changes to the network in the changelog. False by default
-        and not recommended. Only used when an alternative changelog event is being produced (e.g. simplification) to
-        reduce changelog bloat.
-        :return:
+        self, edges_attributes: list[dict], silent: bool = False, ignore_change_log: bool = False
+    ) -> tuple[dict, dict]:
+        """Adds multiple edges, generates unique link ids for each.
+
+        Args:
+            edges_attributes (list[dict]):
+                List of edges, each item in list is a dictionary defining the edge attributes.
+                Contains at least `'from': node_id` and `'to': node_id` entries.
+            silent (bool, optional):  whether to mute stdout logging messages. Defaults to False.
+            ignore_change_log (bool, optional):
+                Whether to ignore logging changes to the network in the changelog.
+                Not recommended.
+                Only used when an alternative changelog event is being produced (e.g. simplification) to reduce changelog bloat.
+                Defaults to False.
+
+        Raises:
+            RuntimeError: Edge `from` and `to` nodes must exist in the network.
+
+        Returns:
+            tuple[dict, dict]:
+                First dict is a mapping from input link IDs to internal link IDs (IDs reindexed if there is any name clashes with existing links).
+                Second dict is `edge_attributes` with link IDs updated according to the mapping of the first dict.
         """
         # check for compulsory attribs
         df_edges = pd.DataFrame(edges_attributes)
@@ -917,21 +1046,27 @@ class Network:
         link_id: Union[str, int],
         u: Union[str, int],
         v: Union[str, int],
-        multi_edge_idx: int = None,
-        attribs: dict = None,
+        multi_edge_idx: Optional[int] = None,
+        attribs: Optional[dict] = None,
         silent: bool = False,
-    ):
-        """
-        Adds an link between u and v with id link_id, if available. If a link between u and v already exists,
-        adds an additional one.
-        :param link_id:
-        :param u: node in the graph
-        :param v: node in the graph
-        :param multi_edge_idx: you can specify which multi index to use if there are other edges between u and v.
-        Will generate new index if already used.
-        :param attribs:
-        :param silent: whether to mute stdout logging messages
-        :return:
+    ) -> str:
+        """Adds a link between u and v with id link_id, if available.
+
+        If a link between u and v already exists, adds an additional one.
+
+        Args:
+            link_id Union[str, int]:
+            u (Union[str, int]): node in the graph.
+            v (Union[str, int]): node in the graph.
+            multi_edge_idx (Optional[int], optional):
+                You can specify which multi index to use if there are other edges between u and v.
+                Will generate new index if already used.
+                Defaults to None.
+            attribs (Optional[dict], optional): Attributes to add to generated link. Defaults to None.
+            silent (bool, optional): Whether to mute stdout logging messages. Defaults to False.
+
+        Returns:
+            str: Generated link ID.
         """
         if link_id in self.link_id_mapping:
             new_link_id = self.generate_index_for_edge(silent=silent)
@@ -999,19 +1134,30 @@ class Network:
 
     def add_links(
         self,
-        links_and_attributes: Dict[str, dict],
+        links_and_attributes: dict[str, dict],
         silent: bool = False,
         ignore_change_log: bool = False,
-    ):
-        """
-        Adds multiple edges, generates their unique link ids
-        :param links_and_attributes: Dictionary of link ids and corresponding edge attributes, each edge attributes
-        contains at least 'from': node_id and 'to': node_id entries,
-        :param silent: whether to mute stdout logging messages
-        :param ignore_change_log: whether to ignore logging changes to the network in the changelog. False by default
-        and not recommended. Only used when an alternative changelog event is being produced (e.g. simplification) to
-        reduce changelog bloat.
-        :return:
+    ) -> tuple[dict, dict]:
+        """Adds multiple links.
+
+        Args:
+            links_and_attributes (list[dict]):
+                List of links, each item in list is a dictionary defining the link ID and its attributes.
+                Contains at least `'from': node_id` and `'to': node_id` entries.
+            silent (bool, optional):  whether to mute stdout logging messages. Defaults to False.
+            ignore_change_log (bool, optional):
+                Whether to ignore logging changes to the network in the changelog.
+                Not recommended.
+                Only used when an alternative changelog event is being produced (e.g. simplification) to reduce changelog bloat.
+                Defaults to False.
+
+        Raises:
+            RuntimeError: Link `from` and `to` nodes must exist in the network.
+
+        Returns:
+            tuple[dict, dict]:
+                First dict is a mapping from input link IDs to internal link IDs (IDs reindexed if there is any name clashes with existing links).
+                Second dict is `links_and_attributes` with link IDs updated according to the mapping of the first dict.
         """
         # check for compulsory attribs
         df_links = pd.DataFrame(links_and_attributes).T
@@ -1200,13 +1346,46 @@ class Network:
         if not silent:
             logging.info(f"Changed Link index from {link_id} to {new_link_id}")
 
-    def subgraph_on_link_conditions(self, conditions, how=any, mixed_dtypes=True):
-        """
-        Gives a subgraph of network.graph based on matching conditions defined in conditions
-        :param conditions as described in graph_operations.extract_links_on_edge_attributes
-        :param how as described in graph_operations.extract_links_on_edge_attributes
-        :param mixed_dtypes as described in graph_operations.extract_links_on_edge_attributes
-        :return:
+    def subgraph_on_link_conditions(
+        self, conditions: Union[list, dict], how: Callable = any, mixed_dtypes: bool = True
+    ) -> nx.MultiDiGraph:
+        """Gives a subgraph of network.graph based on matching conditions defined in conditions.
+
+        Args:
+            conditions (Union[list, dict]):
+                {'attribute_key': 'target_value'} or nested {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}},
+                where 'target_value' could be:
+
+                - single value, string, int, float, where the edge_data[key] == value
+                (if mixed_dtypes==True and in case of set/list edge_data[key], value is in edge_data[key])
+
+                - list or set of single values as above, where edge_data[key] in [value1, value2]
+                (if mixed_dtypes==True and in case of set/list edge_data[key],
+                set(edge_data[key]) & set([value1, value2]) is non-empty)
+
+                - for int or float values, two-tuple bound (lower_bound, upper_bound) where
+                lower_bound <= edge_data[key] <= upper_bound
+                (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
+                edge_data[key] satisfies lower_bound <= item <= upper_bound)
+
+                - function that returns a boolean given the value e.g.
+                ```python
+                def below_exclusive_upper_bound(value):
+                    return value < 100
+                ```
+                (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
+                edge_data[key] returns True after applying function)
+
+            how (Callable, optional):
+                The level of rigour used to match conditions. Defaults to any.
+                - all: means all conditions need to be met
+                - any: means at least one condition needs to be met
+
+            mixed_dtypes (bool, optional):
+                If True, will consider the intersection of single values or lists of values in queried dictionary keys, e.g. as in simplified networks.
+                Defaults to True.
+        Returns:
+            nx.MultiDiGraph: Sub-graph of edges where attribute values match `conditions`.
         """
         links = self.extract_links_on_edge_attributes(
             conditions=conditions, how=how, mixed_dtypes=mixed_dtypes
@@ -1221,10 +1400,11 @@ class Network:
         ]
         return nx.MultiDiGraph(nx.edge_subgraph(self.graph, edges_for_sub))
 
-    def modes(self):
-        """
-        Scans network for 'modes' attribute and returns list of all modes present in the network
-        :return:
+    def modes(self) -> set:
+        """Scans network for 'modes' attribute and returns list of all modes present in the network.
+
+        Returns:
+            set: Modes present in the network.
         """
         modes = set()
         for link, link_attribs in self.links():
@@ -1236,24 +1416,29 @@ class Network:
 
     def find_shortest_path(
         self,
-        from_node,
-        to_node,
-        modes: Union[str, list, set] = None,
-        subgraph: nx.MultiDiGraph = None,
-        return_nodes=False,
-    ):
-        """
-        Finds shortest path between from and to nodes in the graph. If modes specified, finds shortest path in the
-        modal subgraph (using links which have given modes stored under 'modes' key in link attributes). If computing
-        a large number of routes on the same modal subgraph, it is best to find the subgraph using the `modal_subgraph`
-        method and pass it under subgraph to avoid re-computing the subgraph every time.
-        :param from_node: node id in the graph
-        :param to_node: node id in the graph
-        :param modes: string e.g. 'car' or list ['car', 'bike']
-        :param subgraph: nx.MultiDiGraph, preferably the result of `modal_subgraph`
-        :param return_nodes: If True, returns list of node ids defining a route (reminder: there can be more than one
-        link between two nodes, by default this method will return a list of link ids that results in shortest journey)
-        :return: list of link ids defining a route
+        from_node: Union[str, int],
+        to_node: Union[str, int],
+        modes: Optional[Union[str, list, set]] = None,
+        subgraph: Optional[nx.MultiDiGraph] = None,
+        return_nodes: bool = False,
+    ) -> list[Union[str, int]]:
+        """Finds shortest path between from and to nodes in the graph.
+
+        If modes specified, finds shortest path in the modal subgraph (using links which have given modes stored under 'modes' key in link attributes).
+        If computing a large number of routes on the same modal subgraph, it is best to find the subgraph using the `modal_subgraph` method and pass it under subgraph to avoid re-computing the subgraph every time.
+
+        Args:
+            from_node (Union[str, int]):  node id in the graph.
+            to_node (Union[str, int]): node id in the graph.
+            modes (Optional[Union[str, list, set]], optional): String e.g. 'car' or list ['car', 'bike']. Defaults to None.
+            subgraph (Optional[nx.MultiDiGraph], optional): Preferably the result of `Network.modal_subgraph`. Defaults to None.
+            return_nodes (bool, optional):
+                If True, returns list of node ids defining a route
+                (reminder: there can be more than one link between two nodes, by default this method will return a list of link ids that results in shortest journey).
+                Defaults to False.
+
+        Returns:
+            list[Union[str, int]]: List of link IDs defining a route.
         """
         if subgraph is not None:
             g = subgraph
@@ -1271,14 +1456,17 @@ class Network:
                 for u, v in zip(route[:-1], route[1:])
             ]
 
-    def apply_attributes_to_node(self, node_id, new_attributes, silent: bool = False):
-        """
-        Adds, or changes if already present, the attributes in new_attributes. Doesn't replace the dictionary
-        stored at the node currently so no data is lost, unless it is being overwritten.
-        :param node_id: node id to perform the change to
-        :param new_attributes: dictionary of data to add/replace if present
-        :param silent: whether to mute stdout logging messages
-        :return:
+    def apply_attributes_to_node(
+        self, node_id: Union[str, int], new_attributes: dict, silent: bool = False
+    ):
+        """Adds, or changes if already present, the attributes in `new_attributes` in-place.
+
+        Doesn't replace the dictionary stored at the node currently so no data is lost, unless it is being overwritten.
+
+        Args:
+            node_id (Union[str, int]): node id to perform the change to.
+            new_attributes (dict): dictionary of data to add/replace if present.
+            silent (bool, optional): whether to mute stdout logging messages. Defaults to False.
         """
         old_attributes = deepcopy(self.node(node_id))
 
@@ -1300,11 +1488,12 @@ class Network:
             logging.info(f"Changed Node attributes under index: {node_id}")
 
     def apply_attributes_to_nodes(self, new_attributes: dict):
-        """
-        Adds, or changes if already present, the attributes in new_attributes. Doesn't replace the dictionary
-        stored at the node currently so no data is lost, unless it is being overwritten.
-        :param new_attributes: keys are node ids and values are dictionaries of data to add/replace if present
-        :return:
+        """Adds, or changes if already present, the attributes in `new_attributes` in-place.
+
+        Doesn't replace the dictionary stored at the node currently so no data is lost, unless it is being overwritten.
+
+        Args:
+            new_attributes (dict): keys are node ids and values are dictionaries of data to add/replace if present.
         """
         nodes = list(new_attributes.keys())
         old_attribs = [deepcopy(self.node(node)) for node in nodes]
@@ -1317,13 +1506,12 @@ class Network:
         nx.set_node_attributes(self.graph, dict(zip(nodes, new_attribs)))
         logging.info(f"Changed Node attributes for {len(nodes)} nodes")
 
-    def apply_function_to_nodes(self, function, location: str):
-        """
-        Applies function to node attributes dictionary
-        :param function: function of node attributes dictionary returning a value that should be stored
-        under `location`
-        :param location: where to save the results: string defining the key in the nodes attributes dictionary
-        :return:
+    def apply_function_to_nodes(self, function: Callable, location: str):
+        """Applies function to node attributes dictionary.
+
+        Args:
+            function (Callable): Function of node attributes dictionary returning a value that should be stored under `location`.
+            location (str): Where to save the results: string defining the key in the nodes attributes dictionary.
         """
         new_node_attribs = {}
         for node, node_attribs in self.nodes():
@@ -1336,17 +1524,23 @@ class Network:
         self.apply_attributes_to_nodes(new_node_attribs)
 
     def apply_attributes_to_edge(
-        self, u, v, new_attributes, conditions=None, how=any, silent: bool = False
+        self,
+        u: Union[str, int],
+        v: Union[str, int],
+        new_attributes: dict,
+        conditions: Optional[Union[dict, list]] = None,
+        how: Callable = any,
+        silent: bool = False,
     ):
-        """
-        Applies attributes to edges (which optionally match certain criteria)
-        :param u: from node
-        :param v: to node
-        :param new_attributes: attributes data to be applied
-        :param conditions: graph_operations.Filter conditions
-        :param how: graph_operations.Filter how
-        :param silent: whether to mute stdout logging messages
-        :return:
+        """Applies attributes to edges (which optionally match certain criteria).
+
+        Args:
+            u (Union[str, int]): from node.
+            v (Union[str, int]): to node.
+            new_attributes (dict): attributes data to be applied.
+            conditions (Optional[Union[dict, list]], optional): `graph_operations.Filter` conditions. Defaults to None.
+            how (Callable, optional): `graph_operations.Filter` how. Defaults to any.
+            silent (bool, optional): whether to mute stdout logging messages. Defaults to False.
         """
         filter = graph_operations.Filter(conditions=conditions, how=how)
 
@@ -1374,14 +1568,20 @@ class Network:
                 if not silent:
                     logging.info(f"Changed Edge attributes under index: {edge}")
 
-    def apply_attributes_to_edges(self, new_attributes: dict, conditions=None, how=any):
-        """
-        Applies new attributes for edges (optionally satisfying certain criteria)
-        :param new_attributes: dictionary where keys are two tuples (u, v) where u is the from node and v is the to
-        node. The value at the key are the new attributes to be applied to links on edge (u,v)
-        :param conditions: graph_operations.Filter conditions
-        :param how: graph_operations.Filter how
-        :return:
+    def apply_attributes_to_edges(
+        self,
+        new_attributes: dict,
+        conditions: Optional[Union[dict, list]] = None,
+        how: Callable = any,
+    ):
+        """Applies new attributes for edges (optionally satisfying certain criteria).
+
+        Args:
+            new_attributes (dict):
+                Dictionary where keys are two tuples (u, v) where u is the from node and v is the to node.
+                The value at the key are the new attributes to be applied to links on edge (u,v).
+            conditions (Optional[Union[dict, list]], optional): `graph_operations.Filter` conditions. Defaults to None.
+            how (Callable, optional): `graph_operations.Filter` how. Defaults to any.
         """
         filter = graph_operations.Filter(conditions=conditions, how=how)
 
@@ -1408,14 +1608,17 @@ class Network:
 
         logging.info(f"Changed Edge attributes for {len(edge_tuples)} edges")
 
-    def apply_attributes_to_link(self, link_id, new_attributes, silent: bool = False):
-        """
-        Adds, or changes if already present, the attributes in new_attributes. Doesn't replace the dictionary
-        stored at the link currently so no data is lost, unless it is being overwritten.
-        :param link_id: link id to perform the change to
-        :param new_attributes: dictionary of data to add/replace if present
-        :param silent: whether to mute stdout logging messages
-        :return:
+    def apply_attributes_to_link(
+        self, link_id: Union[str, int], new_attributes: dict, silent: bool = False
+    ):
+        """Adds, or changes if already present, the attributes in `new_attributes` in-place.
+
+        Doesn't replace the dictionary stored at the link currently so no data is lost, unless it is being overwritten.
+
+        Args:
+            link_id (Union[str, int]): link id to perform the change to.
+            new_attributes (dict): dictionary of data to add/replace if present.
+            silent (bool, optional): whether to mute stdout logging messages. Defaults to False.
         """
         u, v = self.link_id_mapping[link_id]["from"], self.link_id_mapping[link_id]["to"]
         multi_idx = self.link_id_mapping[link_id]["multi_edge_idx"]
@@ -1440,11 +1643,12 @@ class Network:
             logging.info(f"Changed Link attributes under index: {link_id}")
 
     def apply_attributes_to_links(self, new_attributes: dict):
-        """
-        Adds, or changes if already present, the attributes in new_attributes. Doesn't replace the dictionary
-        stored at the link currently so no data is lost, unless it is being overwritten.
-        :param new_attributes: keys are link ids and values are dictionaries of data to add/replace if present
-        :return:
+        """Adds, or changes if already present, the attributes in `new_attributes` in-place.
+
+        Doesn't replace the dictionary stored at the link currently so no data is lost, unless it is being overwritten.
+
+        Args:
+            new_attributes (dict): keys are link ids and values are dictionaries of data to add/replace if present.
         """
         links = list(new_attributes.keys())
         old_attribs = [deepcopy(self.link(link)) for link in links]
@@ -1459,13 +1663,12 @@ class Network:
         nx.set_edge_attributes(self.graph, dict(zip(edge_tuples, new_attribs)))
         logging.info(f"Changed Link attributes for {len(links)} links")
 
-    def apply_function_to_links(self, function, location: str):
-        """
-        Applies function to link attributes dictionary
-        :param function: function of link attributes dictionary returning a value that should be stored
-        under `location`
-        :param location: where to save the results: string defining the key in the nodes attributes dictionary
-        :return:
+    def apply_function_to_links(self, function: Callable, location: str):
+        """Applies function to link attributes dictionary.
+
+        Args:
+            function (Callable): Function of link attributes dictionary returning a value that should be stored under `location`.
+            location (str): Where to save the results: string defining the key in the nodes attributes dictionary.
         """
         new_link_attribs = {}
         for link_id, link_attribs in self.links():
@@ -1483,12 +1686,12 @@ class Network:
             )
         self.apply_attributes_to_links(new_link_attribs)
 
-    def remove_node(self, node_id, silent: bool = False):
-        """
-        Removes the node n and all adjacent edges
-        :param node_id:
-        :param silent: whether to mute stdout logging messages
-        :return:
+    def remove_node(self, node_id: Union[str, int], silent: bool = False):
+        """Removes the node n and all adjacent edges
+
+        Args:
+            node_id (Union[str, int]): Node ID to remove
+            silent (bool, optional): whether to mute stdout logging messages. Defaults to False.
         """
         self.change_log.remove(
             object_type="node", object_id=node_id, object_attributes=self.node(node_id)
@@ -1498,15 +1701,19 @@ class Network:
         if not silent:
             logging.info(f"Removed Node under index: {node_id}")
 
-    def remove_nodes(self, nodes, ignore_change_log=False, silent=False):
-        """
-        Removes several nodes and all adjacent edges
-        :param nodes: list or set
-        :param ignore_change_log: whether to ignore logging changes to the network in the changelog. False by default
-        and not recommended. Only used when an alternative changelog event is being produced (e.g. simplification) to
-        reduce changelog bloat.
-        :param silent: whether to mute stdout logging messages
-        :return:
+    def remove_nodes(
+        self, nodes: list[Union[str, int]], ignore_change_log: bool = False, silent: bool = False
+    ):
+        """Removes several nodes and all adjacent edges.
+
+        Args:
+            nodes (list[Union[str, int]]): list of nodes to remove.
+            ignore_change_log (bool, optional):
+                Whether to ignore logging changes to the network in the changelog.
+                Not recommended.
+                Only used when an alternative changelog event is being produced (e.g. simplification) to reduce changelog bloat.
+                Defaults to False.
+            silent (bool, optional): Whether to mute stdout logging messages. Defaults to False.
         """
         if not ignore_change_log:
             self.change_log = self.change_log.remove_bunch(
@@ -1519,12 +1726,12 @@ class Network:
         if not silent:
             logging.info(f"Removed {len(nodes)} nodes.")
 
-    def remove_link(self, link_id, silent: bool = False):
-        """
-        Removes the multi edge pertaining to link given
-        :param link_id:
-        :param silent: whether to mute stdout logging messages
-        :return:
+    def remove_link(self, link_id: Union[str, int], silent: bool = False):
+        """Removes the multi edge pertaining to link given.
+
+        Args:
+            link_id (Union[str, int]): Edge to remove.
+            silent (bool, optional): Whether to mute stdout logging messages. Defaults to False.
         """
         self.change_log.remove(
             object_type="link", object_id=link_id, object_attributes=self.link(link_id)
@@ -1536,15 +1743,19 @@ class Network:
         if not silent:
             logging.info(f"Removed link under index: {link_id}")
 
-    def remove_links(self, links, ignore_change_log=False, silent=False):
-        """
-        Removes the multi edges pertaining to links given
-        :param links: set or list
-        :param ignore_change_log: whether to ignore logging changes to the network in the changelog. False by default
-        and not recommended. Only used when an alternative changelog event is being produced (e.g. simplification) to
-        reduce changelog bloat.
-        :param silent: whether to mute stdout logging messages
-        :return:
+    def remove_links(
+        self, links: list[Union[str, int]], ignore_change_log: bool = False, silent: bool = False
+    ):
+        """Removes several edges according to their link IDs
+
+        Args:
+            links (list[Union[str, int]]): list of links to remove.
+            ignore_change_log (bool, optional):
+                Whether to ignore logging changes to the network in the changelog.
+                Not recommended.
+                Only used when an alternative changelog event is being produced (e.g. simplification) to reduce changelog bloat.
+                Defaults to False.
+            silent (bool, optional): Whether to mute stdout logging messages. Defaults to False.
         """
         links = list(links)
         if not ignore_change_log:
@@ -1560,7 +1771,7 @@ class Network:
         if not silent:
             logging.info(f"Removed {len(links)} links")
 
-    def is_strongly_connected(self, modes: Union[list, str, set] = None):
+    def is_strongly_connected(self, modes: Optional[Union[list, str, set]] = None):
         if modes is None:
             g = self.graph
         else:
@@ -1580,13 +1791,20 @@ class Network:
         else:
             return False
 
-    def connect_components(self, modes: Union[list, str, set] = None, weight: float = 1.0):
-        """
-        Connect disconnected subgraphs in the Network graph. Use modes variable to consider a modal subgraph.
+    def connect_components(
+        self, modes: Optional[Union[list, str, set]] = None, weight: float = 1.0
+    ) -> Optional[dict]:
+        """Connect disconnected subgraphs in the Network graph.
+
+        Use modes variable to consider a modal subgraph.
         For a strongly connected MATSim network use only a single (routable) mode at a time.
-        :param modes: str, list or set or network modes to use for computing strongly connected subgraphs
-        :param weight: weight to apply to `frespeed` and `capacity` for scaling, defaults to 1.
-        :return: None, or links and their details if they were added to the Network.
+
+        Args:
+            modes (Optional[Union[list, str, set]], optional): Single mode or iterable of modes to use for computing strongly connected subgraphs. Defaults to None.
+            weight (float, optional): weight to apply to `freespeed` and `capacity` for scaling. Defaults to 1.0.
+
+        Returns:
+            Optional[dict]: None, or links and their details if they were added to the Network.
         """
         if modes is None:
             g = self.graph
@@ -1657,50 +1875,62 @@ class Network:
                 return links_to_add
             else:
                 logging.warning("No links are being added")
+        return None
 
-    def number_of_multi_edges(self, u, v):
-        """
-        number of multi edges on edge from u to v
-        :param u: from node
-        :param v: to node
-        :return:
+    def number_of_multi_edges(self, u: Union[str, int], v: Union[str, int]) -> int:
+        """Number of multi edges on edge from u to v.
+
+        Args:
+            u (Union[str, int]): From node.
+            v (Union[str, int]): To node.
+
+        Returns:
+            int: Number of edges between `u` and `v`.
         """
         if self.graph.has_edge(u, v):
             return len(self.graph.edges(u, v))
         else:
             return 0
 
-    def nodes(self):
+    def nodes(self) -> Iterator[tuple[Union[str, int], Any]]:
         """
-        :return:  Iterator through each node and its attrib (two-tuple)
+        Yields:
+            Iterator through each node and its attrib (two-tuple)
         """
         for id, attrib in self.graph.nodes(data=True):
             yield id, attrib
 
-    def node(self, node_id):
+    def node(self, node_id: Union[str, int]) -> dict:
         """
-        :return:  attribs of the 'node_id'
+        Returns:
+            Attributes of the 'node_id'
         """
         return self.graph.nodes[node_id]
 
-    def edges(self):
+    def edges(self) -> Iterator[tuple[Union[str, int], Union[str, int], Any]]:
         """
-        :return: Iterator through each edge's from, to nodes and its attrib (three-tuple)
+        Yields:
+            Iterator through each edge's from, to nodes and its attrib (three-tuple).
         """
         for u, v in self.graph.edges():
             yield u, v, self.edge(u, v)
 
-    def edge(self, u, v):
-        """
-        :param u: from node of self.graph
-        :param v: to node of self.graph
-        :return:  attribs of the edge from u to  v
+    def edge(self, u: Union[str, int], v: Union[str, int]) -> dict:
+        """Get edge attributes.
+
+        Args:
+            u (Union[str, int]): From node of `self.graph`.
+            v (Union[str, int]): To node of `self.graph`.
+
+        Returns:
+            dict: Attributes of the edge from u to  v.
         """
         return dict(self.graph[u][v])
 
-    def links(self):
+    def links(self) -> Iterator[tuple[Union[str, int], Any]]:
         """
-        :return: Iterator through each link id its attrib (two-tuple)
+        Yields:
+            Iterator through each link id its attrib (two-tuple).
         """
         for link_id in self.link_id_mapping.keys():
             yield link_id, self.link(link_id)
@@ -1710,60 +1940,77 @@ class Network:
         multi_idx = self.link_id_mapping[link]["multi_edge_idx"]
         return u, v, multi_idx
 
-    def link(self, link_id):
-        """
-        :param link_id:
-        :return:
+    def link(self, link_id: Union[str, int]) -> dict:
+        """Get Link attributes.
+
+        Args:
+            link_id (Union[str, int]): Link ID.
+
+        Returns:
+            dict: Link attributes.
         """
         u, v, multi_idx = self.edge_tuple_from_link_id(link_id)
         return dict(self.graph[u][v][multi_idx])
 
     def route_schedule(
         self,
-        services: Union[list, set] = None,
-        solver="cbc",
-        allow_partial=True,
-        distance_threshold=30,
-        step_size=10,
-        additional_modes=None,
-        allow_directional_split=False,
-    ):
-        """
-        Method to find relationship between all Services in Schedule and the Network. It finds closest
-        links in the Network for all stops and finds a network route (ordered list of links in the network) for all
-        Route objects within each Service.
+        services: Optional[Union[list, set]] = None,
+        solver: str = "cbc",
+        allow_partial: bool = True,
+        distance_threshold: int = 30,
+        step_size: int = 10,
+        additional_modes: Optional[dict] = None,
+        allow_directional_split: bool = False,
+    ) -> Optional[set]:
+        """Method to find relationship between all Services in Schedule and the Network.
 
-        It creates new stops: 'old_id:link:link_id' for an 'old_stop' which snapped to 'link_id'. It does not delete
-        old stops.
+        It finds closest links in the Network for all stops and finds a network route (ordered list of links in the network) for all Route objects within each Service.
 
-        If there isn't a link available for snapping within threshold and under modal conditions, an artificial
-        self-loop link will be created as well as any connecting links to that unsnapped stop. This can be switched off
-        by setting allow_partial=False. It will raise PartialMaxStableSetProblem error instead.
+        It creates new stops: 'old_id:link:link_id' for an 'old_stop' which snapped to 'link_id'.
+        It does not delete old stops.
 
-        :param services: you can specify a list of services within the schedule to be snapped, defaults to all services
-        :param solver: you can specify different mathematical solvers. Defaults to CBC, open source solver which can
-        be found here: https://projects.coin-or.org/Cbc . Another good open source choice is GLPK:
-        https://www.gnu.org/software/glpk/. You specify it as a string e.g. 'glpk', 'cbc', 'gurobi'.
-        The solver needs to support MILP - mixed integer linear programming.
-        :param allow_partial: Defaults to True. If there isn't a link available for snapping within threshold and,
-        under modal conditions, an artificial self-loop link will be created as well as any connecting links to that
-        unsnapped stop. If set to False and the problem is partial, it will raise PartialMaxStableSetProblem error
-        instead.
-        :param distance_threshold: in metres, upper bound for how far too look for links to snap to stops.
-        Defaults to 30
-        :param step_size: in metres, how much to increase search area for links (making this smaller than the distance
-        threshold makes the problem less computationally heavy)
-        :param additional_modes: By default the network subgraph considered for snapping and routing will be matching
-        the service modes exactly e.g. just 'bus' mode. You can relax it by adding extra modes
-        e.g. {'tram': {'car', 'rail'}, 'bus': 'car'} - either a set, list of just a single additional mode for a mode
-        in the Schedule. This dictionary need not be exhaustive. Any other modes will be handled in the default way.
-        Referencing modes present under 'modes' attribute of Network links.
-        :param allow_directional_split: Defaults to False i.e. one link will be related to a stop in each Service.
-        For some modes, e.g. rail, it may be beneficial to split this problem based on direction of travel. This usually
-        results in stops snapping to multiple links. Routes' stops and their network routes are updated based on
-        direction too. You may like to investigate directional split for different services using a Service object
-        method: `split_graph`.
-        :return: set of unsnapped services, empty if all snapped, updates Network object and the Schedule object within.
+        If there isn't a link available for snapping within threshold and under modal conditions,
+        an artificial self-loop link will be created as well as any connecting links to that unsnapped stop.
+        This can be switched off by setting allow_partial=False.
+        It will raise PartialMaxStableSetProblem error instead.
+
+        Args:
+            services (Optional[Union[list, set]], optional):
+                You can specify a list of services within the schedule to be snapped.
+                Defaults to None (i.e., all services).
+            solver (str, optional):
+                You can specify different mathematical solvers.
+                Defaults to CBC, open source solver which can be found here: https://projects.coin-or.org/Cbc.
+                Another good open source choice is GLPK: https://www.gnu.org/software/glpk/.
+                You specify it as a string e.g. 'glpk', 'cbc', 'gurobi'.
+                The solver needs to support MILP - mixed integer linear programming.
+            allow_partial (bool, optional):
+                If there isn't a link available for snapping within threshold and, under modal conditions,
+                an artificial self-loop link will be created as well as any connecting links to that unsnapped stop.
+                If set to False and the problem is partial, it will raise PartialMaxStableSetProblem error instead.
+                Defaults to True.
+            distance_threshold (int, optional):
+                In metres, upper bound for how far too look for links to snap to stops. Defaults to 30.
+            step_size (int, optional):
+                In metres, how much to increase search area for links
+                (making this smaller than the distance threshold makes the problem less computationally heavy).
+                Defaults to 10.
+            additional_modes (Optional[dict], optional):
+                By default the network subgraph considered for snapping and routing will be matching the service modes exactly e.g. just 'bus' mode.
+                You can relax it by adding extra modes e.g. {'tram': {'car', 'rail'}, 'bus': 'car'} - either a set, list of just a single additional mode for a mode in the Schedule.
+                This dictionary need not be exhaustive.
+                Any other modes will be handled in the default way.
+                Referencing modes present under 'modes' attribute of Network links.
+                Defaults to None.
+            allow_directional_split (bool, optional):
+                Defaults to False i.e. one link will be related to a stop in each Service.
+                For some modes, e.g. rail, it may be beneficial to split this problem based on direction of travel.
+                This usually results in stops snapping to multiple links.
+                Routes' stops and their network routes are updated based on direction too.
+                You may like to investigate directional split for different services using a Service object method: `split_graph`.
+
+        Returns:
+            Optional[set]: Set of unsnapped services, empty if all snapped, updates Network object and the Schedule object within.
         """
         if self.schedule:
             logging.info("Building Spatial Tree")
@@ -1848,56 +2095,73 @@ class Network:
             return unsnapped_services
         else:
             logging.warning("Schedule object not found")
+            return None
 
     def route_service(
         self,
-        service_id,
-        spatial_tree=None,
-        solver="cbc",
-        allow_partial=True,
-        distance_threshold=30,
-        step_size=10,
-        additional_modes=None,
-        allow_directional_split=False,
-    ):
-        """
-        Method to find relationship between the Service with ID 'service_id' in the Schedule and the Network.
+        service_id: Union[str, int],
+        spatial_tree: Optional[spatial.SpatialTree] = None,
+        solver: str = "cbc",
+        allow_partial: bool = True,
+        distance_threshold: int = 30,
+        step_size: int = 10,
+        additional_modes: Optional[dict] = None,
+        allow_directional_split: bool = False,
+    ) -> Optional[Union[str, int]]:
+        """Method to find relationship between the Service with ID 'service_id' in the Schedule and the Network.
+
         It finds closest links in the Network for all stops and finds a network route (ordered list of links in the
         network) for all Route objects within this Service.
 
-        It creates new stops: 'old_id:link:link_id' for an 'old_stop' which snapped to 'link_id'. It does not delete
-        old stops.
+        It creates new stops: 'old_id:link:link_id' for an 'old_stop' which snapped to 'link_id'.
+        It does not delete old stops.
 
         If there isn't a link available for snapping within threshold and under modal conditions, an artificial
         self-loop link will be created as well as any connecting links to that unsnapped stop. This can be switched off
         by setting allow_partial=False. It will raise PartialMaxStableSetProblem error instead.
 
-        :param service_id: ID of the Service object to snap and route
-        :param spatial_tree: optional, if snapping more than one Service, it may be beneficcial to build the spatial
-        tree which is used for snapping separately and pass it here. This is done simply by importing genet and passing
-        the network object in the following way: genet.utils.spatial.SpatialTree(network_object)
-        :param solver: you can specify different mathematical solvers. Defaults to CBC, open source solver which can
-        be found here: https://projects.coin-or.org/Cbc . Another good open source choice is GLPK:
-        https://www.gnu.org/software/glpk/. You specify it as a string e.g. 'glpk', 'cbc', 'gurobi'.
-        The solver needs to support MILP - mixed integer linear programming.
-        :param allow_partial: Defaults to True. If there isn't a link available for snapping within threshold and
-        under modal conditions, an artificial self-loop link will be created as well as any connecting links to that
-        unsnapped stop. If set to False and the problem is partial, it will raise PartialMaxStableSetProblem error
-        instead.
-        :param distance_threshold: in metres, upper bound for how far too look for links to snap to stops.
-        Defaults to 30
-        :param step_size: in metres, how much to increase search area for links (making this smaller than the distance
-        threshold makes the problem less computationally heavy)
-        :param additional_modes: string, set or list. By default the network subgraph considered for snapping and
-        routing will be matching the service modes exactly e.g. just 'bus' mode. You can relax it by adding extra modes
-        e.g. 'car' or {'car', 'rail'}. Referencing modes present under 'modes' attribute of Network links.
-        :param allow_directional_split: Defaults to False i.e. one link will be related to a stop in each Service.
-        For some modes, e.g. rail, it may be beneficial to split this problem based on direction of travel. This usually
-        results in stops snapping to multiple links. Routes' stops and their network routes are updated based on
-        direction too. You may like to investigate directional split for different services using a Service object
-        method: `split_graph`.
-        :return: None if successful, updates Network object and the Schedule object within. Returns service ID if
-        unsuccesful.
+        Args:
+            service_id (Union[str, int]): ID of the Service object to snap and route
+            spatial_tree (Optional[spatial.SpatialTree], optional):
+                If snapping more than one Service, it may be beneficcial to build the spatial tree which is used for snapping separately and pass it here.
+                This is done simply by importing genet and passing the network object in the following way: genet.utils.spatial.SpatialTree(network_object).
+                Defaults to None.
+            solver (str, optional):
+                You can specify different mathematical solvers.
+                Defaults to CBC, open source solver which can be found here: https://projects.coin-or.org/Cbc.
+                Another good open source choice is GLPK: https://www.gnu.org/software/glpk/.
+                You specify it as a string e.g. 'glpk', 'cbc', 'gurobi'.
+                The solver needs to support MILP - mixed integer linear programming.
+            allow_partial (bool, optional):
+                If there isn't a link available for snapping within threshold and, under modal conditions,
+                an artificial self-loop link will be created as well as any connecting links to that unsnapped stop.
+                If set to False and the problem is partial, it will raise PartialMaxStableSetProblem error instead.
+                Defaults to True.
+            distance_threshold (int, optional):
+                In metres, upper bound for how far too look for links to snap to stops. Defaults to 30.
+            step_size (int, optional):
+                In metres, how much to increase search area for links
+                (making this smaller than the distance threshold makes the problem less computationally heavy).
+                Defaults to 10.
+            additional_modes (Optional[dict], optional):
+                By default the network subgraph considered for snapping and routing will be matching the service modes exactly e.g. just 'bus' mode.
+                You can relax it by adding extra modes e.g. {'tram': {'car', 'rail'}, 'bus': 'car'} - either a set, list of just a single additional mode for a mode in the Schedule.
+                This dictionary need not be exhaustive.
+                Any other modes will be handled in the default way.
+                Referencing modes present under 'modes' attribute of Network links.
+                Defaults to None.
+            allow_directional_split (bool, optional):
+                Defaults to False i.e. one link will be related to a stop in each Service.
+                For some modes, e.g. rail, it may be beneficial to split this problem based on direction of travel.
+                This usually results in stops snapping to multiple links.
+                Routes' stops and their network routes are updated based on direction too.
+                You may like to investigate directional split for different services using a Service object method: `split_graph`.
+
+
+        Returns:
+            Optional[Union[str, int]]:
+                None if successful, updates Network object and the Schedule object within.
+                Returns service ID if unsuccessful.
         """
         if spatial_tree is None:
             spatial_tree = spatial.SpatialTree(self)
@@ -1940,12 +2204,14 @@ class Network:
                 f"modal graph is empty for those modes. Consider teleporting."
             )
             return service.id
+        else:
+            return None
 
     def teleport_service(self, service_ids: Union[str, list, set]):
-        """
-        Teleports service(s) of ID(s) given in `service_ids`
-        :param service_ids: a Service ID or collection of them
-        :return: None, updates Network and Schedule objects
+        """Teleports service(s) of ID(s) given in `service_ids` in-place
+
+        Args:
+            service_ids (Union[str, list, set]): a Service ID or collection of them.
         """
 
         def route_path(ordered_stops):
@@ -2063,17 +2329,27 @@ class Network:
             self.add_links(max_stable_set_changeset.new_links)
         self.apply_attributes_to_links(max_stable_set_changeset.additional_links_modes)
 
-    def reroute(self, _id, additional_modes=None):
-        """
-        Finds network route for a Service of ID=_id or Route of ID=_id, if the Stops for that Route or Service are
-        already snapped to the network (have linkRefId attributes). Checks that those linkRefIds are still in the
-        network, logs a warning if not.
-        :param _id: ID of Route or Service object. If Service, updated route attribute of all Routes contained within
-        the Service object
-        :param additional_modes: string, set or list. By default the network subgraph considered for snapping and
-        routing will be matching the service modes exactly e.g. just 'bus' mode. You can relax it by adding extra modes
-        e.g. 'car' or {'car', 'rail'}. Referencing modes present under 'modes' attribute of Network links.
-        :return: None, updates the `route` attribute of `Route` object(s)
+    def reroute(
+        self, _id: Union[str, int], additional_modes: Optional[Union[str, set, list]] = None
+    ):
+        """Finds network route for a Service of ID=_id or Route of ID=_id, if the Stops for that Route or Service are already snapped to the network (have linkRefId attributes).
+
+        Checks that those linkRefIds are still in the network, logs a warning if not.
+
+        Updates Route/Service object in-place.
+
+        Args:
+            _id (Union[str, int]):
+                ID of Route or Service object.
+                If Service, updated route attribute of all Routes contained within the Service object.
+            additional_modes (Optional[Union[str, set, list]], optional):
+                By default the network subgraph considered for snapping and routing will be matching the service modes exactly e.g. just 'bus' mode.
+                You can relax it by adding extra modes e.g. 'car' or {'car', 'rail'}.
+                Referencing modes present under 'modes' attribute of Network links.
+                Defaults to None.
+
+        Raises:
+            IndexError: ID must be a route or service.
         """
         try:
             self._reroute_service(_id, additional_modes)
@@ -2137,18 +2413,18 @@ class Network:
                 "use a different method to snap and route the Service object containing this Route."
             )
 
-    def services(self):
+    def services(self) -> Iterator[schedule_elements.Service]:
         """
-        Iterator returning Service objects
-        :return:
+        Yields:
+            Iterator returning Service objects
         """
         for service in self.schedule.services():
             yield service
 
-    def schedule_routes(self):
+    def schedule_routes(self) -> Iterator[schedule_elements.Route]:
         """
-        Iterator returning Route objects within the Schedule
-        :return:
+        Yields:
+            Iterator returning Route objects within the Schedule
         """
         for route in self.schedule.routes():
             yield route
@@ -2259,13 +2535,23 @@ class Network:
             logging.info(f"Link with id {link_id} is not in the network.")
             return False
 
-    def has_links(self, link_ids: list, conditions: Union[list, dict] = None, mixed_dtypes=True):
-        """
-        Whether the Network contains the links given in the link_ids list. If conditions is specified, checks whether
-        the Network contains the links specified and those links match the attributes in the conditions dict.
-        :param link_ids: list of link ids e.g. ['1', '102']
-        :param conditions: confer graph_operations.Filter conditions
-        :return:
+    def has_links(
+        self,
+        link_ids: list[Union[str, int]],
+        conditions: Optional[Union[list, dict]] = None,
+        mixed_dtypes: bool = True,
+    ) -> bool:
+        """Whether the Network contains the links given in the link_ids list.
+
+        If conditions is specified, checks whether the Network contains the links specified and those links match the attributes in the conditions dict.
+
+        Args:
+            link_ids (list[Union[str, int]]): List of link ids e.g. ['1', '102'].
+            conditions (Optional[Union[list, dict]], optional): Confer `graph_operations.Filter` conditions. Defaults to None.
+            mixed_dtypes (bool, optional): Confer `graph_operations.Filter` mixed_dtypes. Defaults to True.
+
+        Returns:
+            bool: If True, network contains links given in link_ids list.
         """
         has_all_links = all([self.has_link(link_id) for link_id in link_ids])
         if not conditions:
@@ -2279,7 +2565,7 @@ class Network:
         else:
             return False
 
-    def has_valid_link_chain(self, link_ids: List[str]):
+    def has_valid_link_chain(self, link_ids: list[str]) -> bool:
         for prev_link_id, next_link_id in zip(link_ids[:-1], link_ids[1:]):
             prev_link_id_to_node = self.link_id_mapping[prev_link_id]["to"]
             next_link_id_from_node = self.link_id_mapping[next_link_id]["from"]
@@ -2291,7 +2577,7 @@ class Network:
             return False
         return True
 
-    def route_distance(self, link_ids):
+    def route_distance(self, link_ids: Union[set, list]) -> int:
         if self.has_valid_link_chain(link_ids):
             distance = 0
             for link_id in link_ids:
@@ -2311,7 +2597,9 @@ class Network:
             logging.warning(f"This route is invalid: {link_ids}")
             return 0
 
-    def generate_index_for_node(self, avoid_keys: Union[list, set] = None, silent: bool = False):
+    def generate_index_for_node(
+        self, avoid_keys: Optional[Union[list, set]] = None, silent: bool = False
+    ) -> str:
         existing_keys = set([i for i, attribs in self.nodes()])
         if avoid_keys:
             existing_keys = existing_keys | set(avoid_keys)
@@ -2325,7 +2613,9 @@ class Network:
             logging.info(f"Generated node id {id}.")
         return str(id)
 
-    def generate_indices_for_n_nodes(self, n, avoid_keys: Union[list, set] = None):
+    def generate_indices_for_n_nodes(
+        self, n: int, avoid_keys: Optional[Union[list, set]] = None
+    ) -> set:
         existing_keys = set([i for i, attribs in self.nodes()])
         if avoid_keys:
             existing_keys = existing_keys | set(avoid_keys)
@@ -2339,19 +2629,23 @@ class Network:
         logging.info(f"Generated {len(id_set)} node ids.")
         return id_set
 
-    def link_id_exists(self, link_id):
+    def link_id_exists(self, link_id: Union[str, int]) -> bool:
         if link_id in self.link_id_mapping:
             logging.warning(f"{link_id} already exists.")
             return True
         return False
 
-    def generate_index_for_edge(self, avoid_keys: Union[list, set] = None, silent: bool = False):
+    def generate_index_for_edge(
+        self, avoid_keys: Optional[Union[list, set]] = None, silent: bool = False
+    ) -> str:
         _id = list(self.generate_indices_for_n_edges(n=1, avoid_keys=avoid_keys))[0]
         if not silent:
             logging.info(f"Generated link id {_id}.")
         return str(_id)
 
-    def generate_indices_for_n_edges(self, n, avoid_keys: Union[list, set] = None):
+    def generate_indices_for_n_edges(
+        self, n: int, avoid_keys: Optional[Union[list, set]] = None
+    ) -> set:
         existing_keys = set(self.link_id_mapping.keys())
         if avoid_keys:
             existing_keys = existing_keys | set(avoid_keys)
@@ -2462,16 +2756,24 @@ class Network:
         ]
 
     def generate_validation_report(
-        self, modes_for_strong_connectivity=None, link_metre_length_threshold=1000
-    ):
-        """
+        self,
+        modes_for_strong_connectivity: Optional[list] = None,
+        link_metre_length_threshold: int = 1000,
+    ) -> dict:
+        """Generates validation report.
+
         Generates a dictionary with keys: 'graph', 'schedule' and 'routing' describing validity of the Network's
         underlying graph, the schedule services and then the intersection of the two which is the routing of schedule
         services onto the graph.
-        :param modes_for_strong_connectivity: list of modes in the network that need to be checked for strong
-            connectivity. Defaults to 'car', 'walk' and 'bike'
-        :param link_metre_length_threshold: in meters defaults to 1000, i.e. 1km
-        :return:
+
+        Args:
+            modes_for_strong_connectivity (Optional[list], optional):
+                List of modes in the network that need to be checked for strong connectivity.
+                Defaults to None (['car', 'walk', 'bike']).
+            link_metre_length_threshold (int, optional): In meters defaults to 1000, i.e. 1km. Defaults to 1000.
+
+        Returns:
+            dict: Validation report
         """
         logging.info("Checking validity of the Network")
         logging.info("Checking validity of the Network graph")
@@ -2572,11 +2874,14 @@ class Network:
         report["is_valid_network"] = is_valid_network
         return report
 
-    def report_on_link_attribute_condition(self, attribute, condition):
+    def report_on_link_attribute_condition(self, attribute: str, condition: Callable) -> dict:
         """
-        :param attribute: one of the link attributes, e.g. 'length'
-        :param condition: callable, condition for link[attribute] to satisfy
-        :return:
+        Args:
+            attribute (str): One of the link attributes, e.g. 'length'.
+            condition (Callable): Condition for link[attribute] to satisfy.
+
+        Returns:
+            dict: Report.
         """
         if isinstance(attribute, dict):
             conditions = dict_support.nest_at_leaf(deepcopy(attribute), condition)
@@ -2609,15 +2914,19 @@ class Network:
             )
         return con_desc
 
-    def generate_standard_outputs(self, output_dir, gtfs_day="19700101", include_shp_files=False):
-        """
-        Generates geojsons that can be used for generating standard kepler visualisations.
-        These can also be used for validating network for example inspecting link capacity, freespeed, number of lanes,
-        the shape of modal subgraphs.
-        :param output_dir: path to folder where to save resulting geojsons
-        :param gtfs_day: day in format YYYYMMDD for the network's schedule for consistency in visualisations,
-        defaults to 1970/01/01 otherwise
-        :return: None
+    def generate_standard_outputs(
+        self, output_dir: str, gtfs_day: str = "19700101", include_shp_files: bool = False
+    ):
+        """Generates geojsons that can be used for generating standard kepler visualisations.
+
+        These can also be used for validating network for example inspecting link capacity, freespeed, number of lanes, the shape of modal subgraphs.
+
+        Args:
+            output_dir (str): path to folder where to save resulting geojsons.
+            gtfs_day (str, optional):
+                Day in format YYYYMMDD for the network's schedule for consistency in visualisations,
+                Defaults to "19700101" (1970-01-01).
+            include_shp_files (bool, optional): If True, also store shapefiles. Defaults to False.
         """
         geojson.generate_standard_outputs(self, output_dir, gtfs_day, include_shp_files)
         logging.info("Finished generating standard outputs. Zipping folder.")
@@ -2641,16 +2950,18 @@ class Network:
 
     def update_link_auxiliary_files(self, id_map: dict):
         """
-        :param id_map: dict map between old link ID and new link ID
-        :return:
+
+        Args:
+            id_map (dict): dict map between old link ID and new link ID.
         """
         for name, aux_file in self.auxiliary_files["link"].items():
             aux_file.apply_map(id_map)
 
     def update_node_auxiliary_files(self, id_map: dict):
         """
-        :param id_map: dict map between old node ID and new node ID
-        :return:
+
+        Args:
+            id_map (dict): dict map between old node ID and new node ID
         """
         for name, aux_file in self.auxiliary_files["node"].items():
             aux_file.apply_map(id_map)
@@ -2664,11 +2975,11 @@ class Network:
         self.change_log.export(os.path.join(output_dir, "network_change_log.csv"))
         self.write_auxiliary_files(os.path.join(output_dir, "auxiliary_files"))
 
-    def write_to_matsim(self, output_dir):
-        """
-        Writes Network and Schedule (if applicable) to MATSim xml format
-        :param output_dir: output directory
-        :return:
+    def write_to_matsim(self, output_dir: str):
+        """Writes Network and Schedule (if applicable) to MATSim xml format.
+
+        Args:
+            output_dir (str): Output directory.
         """
         persistence.ensure_dir(output_dir)
         matsim_xml_writer.write_matsim_network(output_dir, self)
@@ -2683,11 +2994,11 @@ class Network:
             "links": dict_support.dataframe_to_dict(_network["links"].T),
         }
 
-    def write_to_json(self, output_dir):
-        """
-        Writes Network and Schedule (if applicable) to a single JSON file with nodes and links
-        :param output_dir: output directory
-        :return:
+    def write_to_json(self, output_dir: str):
+        """Writes Network and Schedule (if applicable) to a single JSON file with nodes and links.
+
+        Args:
+            output_dir (str): Output directory.
         """
         persistence.ensure_dir(output_dir)
         logging.info(f"Saving Network to JSON in {output_dir}")
@@ -2697,12 +3008,13 @@ class Network:
             self.schedule.write_to_json(output_dir)
         self.write_extras(output_dir)
 
-    def write_to_geojson(self, output_dir, epsg: str = None):
-        """
-        Writes Network graph and Schedule (if applicable) to nodes and links geojson files.
-        :param output_dir: output directory
-        :param epsg: projection if the geometry is to be reprojected, defaults to own projection
-        :return:
+    def write_to_geojson(self, output_dir: str, epsg: Optional[str] = None):
+        """Writes Network graph and Schedule (if applicable) to nodes and links geojson files.
+
+        Args:
+            output_dir (str): Output directory.
+            epsg (Optional[str], optional):
+                Projection if the geometry is to be reprojected. Defaults to None (no reprojection).
         """
         persistence.ensure_dir(output_dir)
         _network = self.to_geodataframe()
@@ -2722,10 +3034,11 @@ class Network:
             self.schedule.write_to_geojson(output_dir, epsg)
         self.write_extras(output_dir)
 
-    def to_geodataframe(self):
-        """
-        Generates GeoDataFrames of the Network graph in Network's crs
-        :return: dict with keys 'nodes' and 'links', values are the GeoDataFrames corresponding to nodes and links
+    def to_geodataframe(self) -> dict:
+        """Generates GeoDataFrames of the Network graph in Network's crs.
+
+        Returns:
+            dict: dict with keys 'nodes' and 'links', values are the GeoDataFrames corresponding to nodes and links.
         """
         return geojson.generate_geodataframes(self.graph)
 
@@ -2741,12 +3054,14 @@ class Network:
         )
         return _network
 
-    def write_to_csv(self, output_dir, gtfs_day="19700101"):
-        """
-        Writes nodes and links tables for the Network and if there is a Schedule, exports it to a GTFS-like format.
-        :param output_dir: output directory
-        :param gtfs_day: defaults to 19700101, day which is represented in the Schedule
-        :return:
+    def write_to_csv(self, output_dir: str, gtfs_day: str = "19700101"):
+        """Writes nodes and links tables for the Network and if there is a Schedule, exports it to a GTFS-like format.
+
+        Args:
+            output_dir (str): path to folder where to save resulting CSVs.
+            gtfs_day (str, optional):
+                Day in format YYYYMMDD which is represented in the network's schedule.
+                Defaults to "19700101" (1970-01-01).
         """
         network_csv_folder = os.path.join(output_dir, "network")
         schedule_csv_folder = os.path.join(output_dir, "schedule")
@@ -2761,14 +3076,19 @@ class Network:
         self.write_extras(network_csv_folder)
 
     def get_node_elevation_dictionary(
-        self, elevation_tif_file_path, null_value: float, run_validation=False
-    ):
-        """
-        Takes an elevation raster file in .tif format, and creates a dictionary with z-value for each network node;
-        can then use self.apply_attributes_to_nodes() function to add elevation as a node attribute to the network
-        :param elevation_tif_file_path: path to the elevation raster file in .tif format
-        :param null_value: value that represents null in the elevation raster file
-        :return: dict in format {node_id : {'z': z}}
+        self, elevation_tif_file_path: str, null_value: float, run_validation: bool = False
+    ) -> dict:
+        """Takes an elevation raster file in .tif format, and creates a dictionary with z-value for each network node.
+
+        Can then use self.apply_attributes_to_nodes() function to add elevation as a node attribute to the network.
+
+        Args:
+            elevation_tif_file_path (str): path to the elevation raster file in .tif format.
+            null_value (float): value that represents null in the elevation raster file
+            run_validation (bool, optional): If True, create a validation report and send to logging INFO level. Defaults to False.
+
+        Returns:
+            dict: Elevation dictionary in format `{node_id : {'z': z}}`.
         """
         img = elevation.get_elevation_image(elevation_tif_file_path)
         elevation_dict = {}
@@ -2787,13 +3107,17 @@ class Network:
 
         return elevation_dict
 
-    def get_link_slope_dictionary(self, elevation_dict):
-        """
-        Takes a dictionary of z-value for each network node (as created by get_node_elevation_dictionary() function,
-        calculates link slope and returns a dictionary of link IDs and their slopes; can then use
-        self.apply_attributes_to_links() function to add slope as a link attribute to the network.
-        :param elevation_dict: dict in format {node_id : {'z': z}}
-        :return: dict in format {link_id : {'slope': slope}}, where slope is a float
+    def get_link_slope_dictionary(self, elevation_dict: dict) -> dict:
+        """Takes a dictionary of z-value for each network node (as created by get_node_elevation_dictionary() function,
+        calculates link slope and returns a dictionary of link IDs and their slopes.
+
+        Can then use self.apply_attributes_to_links() function to add slope as a link attribute to the network.
+
+        Args:
+            elevation_dict (dict): dict in format `{node_id : {'z': z}}`
+
+        Returns:
+            dict: dict in format `{link_id : {'slope': slope}}`, where slope is a float.
         """
         slope_dict = {}
 
@@ -2817,18 +3141,27 @@ class Network:
 
         return slope_dict
 
-    def split_link_at_node(self, link_id, node_id, distance_threshold=1):
-        """
-        Takes a link and node, and splits the link at the point to create 2 new links;
-        the old link is then deleted.
-        Unlike `split_link_at_point` this allows multiple links being split using the same mode - meaning they are
-        connected and using the same junction, e.g. two links going in opposite directions. However, the node has to
-        be situated on the geometry of the links involved so it's recommended you use
-        `genet.spatial.snap_point_to_line` to align the node before adding it.
-        :param link_id: ID of the link to split
-        :param node_id: ID of the node in the graph to split at.
-        :param distance_threshold: how close the node needs to be to the link to be allowed to split it
-        :return: None
+    def split_link_at_node(
+        self, link_id: Union[str, int], node_id: Union[str, int], distance_threshold: int = 1
+    ) -> dict:
+        """Takes a link and node, and splits the link at the point to create 2 new links.
+
+        The old link is then deleted.
+
+        Unlike `split_link_at_point` this allows multiple links being split using the same mode -
+        meaning they are connected and using the same junction, e.g. two links going in opposite directions.
+        However, the node has to be situated on the geometry of the links involved so it's recommended you use `genet.spatial.snap_point_to_line` to align the node before adding it.
+
+        Args:
+            link_id (Union[str, int]): ID of the link to split.
+            node_id (Union[str, int]): ID of the node in the graph to split at.
+            distance_threshold (int, optional): How close the node needs to be to the link to be allowed to split it. Defaults to 1.
+
+        Raises:
+            exceptions.MisalignedNodeError: node must be close enough to the link to split it.
+
+        Returns:
+            dict: updated node attributes and links.
         """
         # check if point is on the link LineString
         node_attribs = self.node(node_id)
@@ -2919,15 +3252,26 @@ class Network:
 
         return {"node_attributes": node_attribs, "links": links}
 
-    def split_link_at_point(self, link_id, x=None, y=None, node_id=None):
-        """
-        Takes a link and point coordinates, and splits the link at the point to create 2 new links;
-        the old link is then deleted. A new node is added too
-        :param link_id: ID of the link to split
-        :param x: x-coordinates of the point to split at
-        :param y: y-coordinates of the point to split at
-        :param node_id: Suggested ID for the resulting node in the graph
-        :return: updates the graph, returns data for node and links that were added
+    def split_link_at_point(
+        self,
+        link_id: Union[str, int],
+        x: Union[str, int],
+        y: Union[str, int],
+        node_id: Optional[Union[str, int]] = None,
+    ) -> dict:
+        """Takes a link and point coordinates, and splits the link at the point to create 2 new links.
+
+        the old link is then deleted.
+        A new node is added too.
+
+        Args:
+            link_id (Union[str, int]): ID of the link to split
+            x (Union[str, int]): x-coordinates of the point to split at.
+            y (Union[str, int]): y-coordinates of the point to split at.
+            node_id (Optional[Union[str, int]], optional): Suggested ID for the resulting node in the graph. Defaults to None.
+
+        Returns:
+            dict: updates the graph, returns data for node and links that were added.
         """
         if node_id is None:
             node_id = self.generate_index_for_node()
@@ -3019,7 +3363,7 @@ class Network:
         return report
 
 
-def replace_link_on_pt_route(route: List[str], mapping: Dict[str, Union[str, list]]):
+def replace_link_on_pt_route(route: list[str], mapping: dict[str, Union[str, list]]):
     new_route: list = []
     for link in route:
         mapped_link = mapping.get(link, link)

--- a/genet/max_stable_set.py
+++ b/genet/max_stable_set.py
@@ -428,10 +428,14 @@ class MaxStableSet:
                 "partial, this will result in gaps in routed paths."
             )
 
-    def routed_path(self, ordered_stops):
-        """
-        :param ordered_stops: list of stops in the route (not artificial/snapped stops)
-        :return:
+    def routed_path(self, ordered_stops: list) -> list:
+        """Get a routed path based on list of ordered stops.
+
+        Args:
+            ordered_stops (list): list of stops in the route (not artificial/snapped stops).
+
+        Returns:
+            list: Routed path.
         """
         path = []
         for u, v in zip(ordered_stops[:-1], ordered_stops[1:]):

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -2852,6 +2852,9 @@ class Schedule(ScheduleElement):
             # assumed to be a shapely.geometry input
             return self._find_stops_on_shapely_geometry(region_input)
 
+    def _add_additional_attribute_to_graph(self, k, v):
+        raise NotImplementedError
+
     def _find_stops_on_geojson(self, geojson_input):
         shapely_input = spatial.read_geojson_to_shapely(geojson_input)
         return self._find_stops_on_shapely_geometry(shapely_input)

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -4,11 +4,11 @@ import json
 import logging
 import math
 import os
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime, timedelta
-from typing import Dict, List, Set, Tuple, Union
+from typing import Callable, Iterator, Literal, Optional, Union
 
 import dictdiffer
 import geopandas as gpd
@@ -17,9 +17,11 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 import yaml
+from keplergl import KeplerGl
 from pandas import DataFrame, Series
 from pyproj import Geod, Transformer
 from s2sphere import CellId
+from shapely.geometry.base import BaseGeometry
 
 import genet.modify.change_log as change_log
 import genet.modify.schedule as mod_schedule
@@ -50,12 +52,13 @@ from genet.exceptions import (
 SPATIAL_TOLERANCE = 8
 
 
-class ScheduleElement:
+class ScheduleElement(ABC):
     """
     Base class for Route, Service and Schedule
     """
 
     def __init__(self):
+        self._graph: nx.DiGraph
         # check if in graph first
         if "crs" in self._graph.graph:
             self.epsg = self._graph.graph["crs"]
@@ -79,13 +82,13 @@ class ScheduleElement:
         else:
             raise RouteIndexError(f"Route with index {route_id} not found")
 
-    def _stop_ids_in_graph(self, stop_ids: List[str]):
+    def _stop_ids_in_graph(self, stop_ids: list[str]):
         return set(stop_ids).issubset(set(self._graph.nodes))
 
-    def _route_ids_in_graph(self, route_ids: List[str]):
+    def _route_ids_in_graph(self, route_ids: list[str]):
         return set(route_ids).issubset(set(self._graph.graph["routes"].keys()))
 
-    def _service_ids_in_graph(self, service_ids: List[str]):
+    def _service_ids_in_graph(self, service_ids: list[str]):
         return set(service_ids).issubset(set(self._graph.graph["services"].keys()))
 
     def change_log(self):
@@ -96,10 +99,10 @@ class ScheduleElement:
         pass
 
     def add_additional_attributes(self, attribs: dict):
-        """
-        adds attributes defined by keys of the attribs dictionary with values of the corresponding values
-        :param attribs: the additional attributes {attribute_name: attribute_value}
-        :return:
+        """Adds attributes defined by keys of the attribs dictionary with values of the corresponding values.
+
+        Args:
+            attribs (dict): The additional attributes `{attribute_name: attribute_value}`
         """
         for k, v in attribs.items():
             if k not in self.__dict__:
@@ -114,11 +117,16 @@ class ScheduleElement:
     def reference_nodes(self):
         pass
 
-    def route_reference_nodes(self, route_id):
-        """
-        Method to extract nodes for a route straight from the graph, equivalent to route_object.reference_nodes() but
-        faster if used from a higher order object like Service or Schedule
-        :return: graph nodes for the route with ID: route_id - not ordered
+    def route_reference_nodes(self, route_id: Union[str, int]) -> set:
+        """Method to extract nodes for a route straight from the graph.
+
+        Equivalent to route_object.reference_nodes() but faster if used from a higher order object like Service or Schedule.
+
+        Args:
+            route_id (Union[str, int]): Route in graph.
+
+        Returns:
+            set: graph nodes for the route with ID: route_id - not ordered
         """
         return {
             node
@@ -126,11 +134,16 @@ class ScheduleElement:
             if route_id in node_routes
         }
 
-    def service_reference_nodes(self, service_id):
-        """
-        Method to extract nodes for a service straight from the graph, equivalent to service_object.reference_nodes()
-        but faster if used from a higher order object: Schedule
-        :return: graph nodes for the service with ID: service_id - not ordered
+    def service_reference_nodes(self, service_id: Union[str, int]) -> set:
+        """Method to extract nodes for a service straight from the graph.
+
+        Equivalent to service_object.reference_nodes() but faster if used from a higher order object: Schedule.
+
+        Args:
+            service_id (Union[str, int]): Service in graph.
+
+        Returns:
+            set: graph nodes for the service with ID: service_id - not ordered.
         """
         return {
             node
@@ -142,11 +155,16 @@ class ScheduleElement:
     def reference_edges(self):
         pass
 
-    def route_reference_edges(self, route_id):
-        """
-        Method to extract edges for a route straight from the graph, equivalent to route_object.reference_edges() but
-        faster if used from a higher order object like Service or Schedule
-        :return: graph edges for the route with ID: route_id
+    def route_reference_edges(self, route_id: Union[str, int]) -> set:
+        """Method to extract edges for a route straight from the graph.
+
+        Equivalent to route_object.reference_edges() but faster if used from a higher order object like Service or Schedule.
+
+        Args:
+            route_id (Union[str, int]): Route in graph.
+
+        Returns:
+            set: graph edges for the route with ID: route_id
         """
         return {
             (u, v)
@@ -154,11 +172,17 @@ class ScheduleElement:
             if route_id in edge_routes
         }
 
-    def service_reference_edges(self, service_id):
-        """
-        Method to extract nodes for a service straight from the graph, equivalent to service_object.reference_edges()
-        but faster if used from a higher order object: Schedule
-        :return: graph edges for the service with ID: service_id
+    def service_reference_edges(self, service_id: Union[str, int]) -> set:
+        """Method to extract nodes for a service straight from the graph
+
+        Equivalent to service_object.reference_edges() but faster if used from a higher order object: Schedule.
+
+        Args:
+            service_id (Union[str, int]): Service in graph.
+
+        Returns:
+            set: graph edges for the service with ID: service_id
+
         """
         return {
             (u, v)
@@ -166,46 +190,64 @@ class ScheduleElement:
             if service_id in edge_services
         }
 
-    def _remove_routes_from_nodes(self, nodes: Set[str], route_ids: Set[str]):
+    @abstractmethod
+    def plot(self, output_dir: str = "", data: Union[bool, set] = False) -> KeplerGl:
+        """Plots the schedule element on a kepler map.
+
+        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install.
+
+        Args:
+            output_dir (str, optional): Output directory for the image, if passed, will save plot to html. Defaults to "".
+            data (Union[bool, set], optional):
+                If False, only the geometry and ID will be visible.
+                If True, will visualise all data on the map (not suitable for large networks)
+                If a set of keys e.g. {'name'}, will visualise those keys.
+                Defaults to False.
+
+        Returns:
+            KeplerGl: Kepler plot object
+        """
+
+    def _remove_routes_from_nodes(self, nodes: set[str], route_ids: set[str]):
         for node in nodes:
             self._graph.nodes[node]["routes"] = self._graph.nodes[node]["routes"] - route_ids
 
-    def _remove_routes_from_edges(self, edges: Set[Tuple[str, str]], route_ids: Set[str]):
+    def _remove_routes_from_edges(self, edges: set[tuple[str, str]], route_ids: set[str]):
         for u, v in edges:
             self._graph[u][v]["routes"] = self._graph[u][v]["routes"] - route_ids
 
-    def _add_routes_to_nodes(self, nodes: Set[str], route_ids: Set[str]):
+    def _add_routes_to_nodes(self, nodes: set[str], route_ids: set[str]):
         for node in nodes:
             self._graph.nodes[node]["routes"] = self._graph.nodes[node]["routes"] | route_ids
 
-    def _add_routes_to_edges(self, edges: Set[Tuple[str, str]], route_ids: Set[str]):
+    def _add_routes_to_edges(self, edges: set[tuple[str, str]], route_ids: set[str]):
         for u, v in edges:
             self._graph[u][v]["routes"] = self._graph[u][v]["routes"] | route_ids
 
-    def _remove_services_from_nodes(self, nodes: Set[str], service_ids: Set[str]):
+    def _remove_services_from_nodes(self, nodes: set[str], service_ids: set[str]):
         for node in nodes:
             self._graph.nodes[node]["services"] = self._graph.nodes[node]["services"] - service_ids
 
-    def _remove_services_from_edges(self, edges: Set[Tuple[str, str]], service_ids: Set[str]):
+    def _remove_services_from_edges(self, edges: set[tuple[str, str]], service_ids: set[str]):
         for u, v in edges:
             self._graph[u][v]["services"] = self._graph[u][v]["services"] - service_ids
 
-    def _add_services_to_nodes(self, nodes: Set[str], service_ids: Set[str]):
+    def _add_services_to_nodes(self, nodes: set[str], service_ids: set[str]):
         for node in nodes:
             self._graph.nodes[node]["services"] = self._graph.nodes[node]["services"] | service_ids
 
-    def _add_services_to_edges(self, edges: Set[Tuple[str, str]], service_ids: Set[str]):
+    def _add_services_to_edges(self, edges: set[tuple[str, str]], service_ids: set[str]):
         for u, v in edges:
             self._graph[u][v]["services"] = self._graph[u][v]["services"] | service_ids
 
-    def _generate_services_on_nodes(self, nodes: Set[str]):
+    def _generate_services_on_nodes(self, nodes: set[str]):
         for node in nodes:
             self._graph.nodes[node]["services"] = {
                 self._graph.graph["route_to_service_map"][r_id]
                 for r_id in self._graph.nodes[node]["routes"]
             }
 
-    def _generate_services_on_edges(self, edges: Set[Tuple[str, str]]):
+    def _generate_services_on_edges(self, edges: set[tuple[str, str]]):
         for u, v in edges:
             self._graph[u][v]["services"] = {
                 self._graph.graph["route_to_service_map"][r_id]
@@ -220,10 +262,10 @@ class ScheduleElement:
         }
         return Stop(**stop_data)
 
-    def stops(self):
+    def stops(self) -> Iterator["Stop"]:
         """
-        Iterable returns stops in the Schedule Element
-        :return:
+        Yields:
+            Iterable returns stops in the Schedule Element
         """
         for s in self.reference_nodes():
             yield self.stop(s)
@@ -256,11 +298,14 @@ class ScheduleElement:
     def stop_to_route_ids_map(self):
         return dict(self.graph().nodes(data="routes"))
 
-    def reproject(self, new_epsg, processes=1):
-        """
-        Changes projection of the element to new_epsg
-        :param new_epsg: 'epsg:1234'
-        :return:
+    def reproject(self, new_epsg: str, processes: int = 1):
+        """Changes projection of the element to `new_epsg`.
+
+        Args:
+            new_epsg (str):
+                New projection, e.g., "epsg:1234".
+            processes (int, optional):
+                Number of parallel processes to use when reprojecting. Defaults to 1.
         """
         if not self.stops_have_this_projection(new_epsg):
             g = self.graph()
@@ -299,34 +344,91 @@ class ScheduleElement:
         return None
 
     @abstractmethod
-    def service_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        pass
+    def service_attribute_data(
+        self, keys: Union[list, str], index_name: Optional[str] = None
+    ) -> pd.DataFrame:
+        """Generates a pandas.DataFrame object indexed by Service IDs, with attribute data stored for Services under `key`.
 
-    @abstractmethod
-    def route_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        pass
-
-    @abstractmethod
-    def stop_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        pass
-
-    @abstractmethod
-    def trips_with_stops_to_dataframe(self, gtfs_day="19700101") -> pd.DataFrame:
-        pass
-
-    def speed_geodataframe(self, network_factor=1.3, gdf_network_links=None) -> gpd.GeoDataFrame:
+        Args:
+            keys (Union[list, str]):
+                List of either a string e.g. 'name', or if accessing nested information, a dictionary.
+                E.g. `{'attributes': {'osm:way:name': 'text'}}`.
+            index_name (Optional[str], optional): gives the index_name to dataframes index. Defaults to None.
+        Returns:
+            pd.DataFrame: Service attribute data
         """
-        DataFrame of speed for PT routes, in metres/second for each stop pair.
-        Note well:
-         - The unit of metres is not guaranteed - this assumes the object is in local metre-based projection.
-         - If you pass a GeoDataFrame of genet.Network links you will get routed speeds as well as teleported with a
-         factor
-         - Assumes genet.Network links geometry if passed. If not, gives the stop-to-stop line geometry
 
-        :param network_factor: Network factor (default 1.3) to be applied to the Euclidean distance between stops
-        :param gdf_network_links: GeoDataFrame of genet.Network links, can be obtained using:
-            genet.Network.to_geodataframe()['links']
-        :return:
+    @abstractmethod
+    def route_attribute_data(self, keys: Union[list, str], index_name: Optional[str] = None):
+        """Generates a pandas.DataFrame object indexed by Route IDs, with attribute data stored for Routes under `key`.
+
+        Args:
+            keys (Union[list, str]):
+                List of either a string e.g. 'name', or if accessing nested information, a dictionary.
+                E.g. `{'attributes': {'osm:way:name': 'text'}}`.
+            index_name (Optional[str], optional): gives the index_name to dataframes index. Defaults to None.
+        Returns:
+            pd.DataFrame: Route attribute data
+        """
+
+    @abstractmethod
+    def stop_attribute_data(self, keys: Union[list, str], index_name: Optional[str] = None):
+        """Generates a pandas.DataFrame object indexed by Stop IDs, with attribute data stored for Stops under `key`.
+
+        Args:
+            keys (Union[list, str]):
+                List of either a string e.g. 'name', or if accessing nested information, a dictionary.
+                E.g. `{'attributes': {'osm:way:name': 'text'}}`.
+            index_name (Optional[str], optional): gives the index_name to dataframes index. Defaults to None.
+        Returns:
+            pd.DataFrame: Stop attribute data
+        """
+
+    @abstractmethod
+    def trips_with_stops_to_dataframe(self, gtfs_day: str = "19700101") -> pd.DataFrame:
+        """Generates a DataFrame holding all the trips,
+        their movements from stop to stop (in datetime with given GTFS day, if specified in `gtfs_day`) and vehicle IDs,
+        next to the route ID and service ID.
+
+        Args:
+            gtfs_day (str, optional): day used for GTFS when creating the network in YYYYMMDD format. Defaults to "19700101".
+
+        Returns:
+            pd.DataFrame: Trips.
+        """
+
+    def route_trips_with_stops_to_dataframe(self, gtfs_day: str = "19700101") -> pd.DataFrame:
+        logging.warning(
+            "`route_trips_with_stops_to_dataframe` method is deprecated and will be replaced by "
+            "`trips_to_dataframe` in later versions."
+        )
+        return self.trips_with_stops_to_dataframe(gtfs_day)
+
+    def route_trips_to_dataframe(self, gtfs_day="19700101"):
+        logging.warning(
+            "`route_trips_to_dataframe` method is deprecated and will be replaced by `trips_to_dataframe`"
+            "in later versions."
+        )
+        return self.trips_to_dataframe(gtfs_day)
+
+    def speed_geodataframe(
+        self, network_factor: float = 1.3, gdf_network_links: Optional[gpd.GeoDataFrame] = None
+    ) -> gpd.GeoDataFrame:
+        """DataFrame of speed for PT routes, in metres/second for each stop pair.
+
+        !!! note
+            - The unit of metres is not guaranteed - this assumes the object is in local metre-based projection.
+            - If you pass a GeoDataFrame of genet.Network links you will get routed speeds as well as teleported with a factor
+            - Assumes genet.Network links geometry if passed. If not, gives the stop-to-stop line geometry
+
+        Args:
+            network_factor (float, optional): Network factor to be applied to the Euclidean distance between stops. Defaults to 1.3.
+            gdf_network_links (Optional[gpd.GeoDataFrame], optional):
+                GeoDataFrame of genet.Network links, can be obtained using: `genet.Network.to_geodataframe()['links']`.
+                Defaults to None.
+
+        Returns:
+            gpd.GeoDataFrame: Speeds for public transport routes.
         """
         df = self.trips_with_stops_to_dataframe()
         df["time"] = (df["arrival_time"] - df["departure_time"]).dt.total_seconds()
@@ -381,12 +483,14 @@ class ScheduleElement:
             df.drop(["u", "v"], axis=1, inplace=True)
         return df.drop(["time", "distance", "network_distance"], axis=1)
 
-    def average_route_speeds(self, network_factor=1.3) -> dict:
-        """
-        Average speed for each route in object
-        :param network_factor: Does not consider network routes, network factor (default 1.3) is applied to Euclidean
-            distance.
-        :return: Dictionary {route_ID: average_speed_in_m_per_s}
+    def average_route_speeds(self, network_factor: float = 1.3) -> dict:
+        """Average speed for each route in object.
+
+        Args:
+            network_factor (float, optional): Does not consider network routes, network factor is applied to Euclidean distance. Defaults to 1.3.
+
+        Returns:
+            dict: Dictionary `{route_ID: average_speed_in_m_per_s}`
         """
         df = self.speed_geodataframe(network_factor=network_factor)
         # computing with all trips is redundant as the speeds for each trip for the same route are the same we can
@@ -395,20 +499,55 @@ class ScheduleElement:
         return df.groupby("route_id")["speed"].mean().to_dict()
 
     @abstractmethod
-    def trips_to_dataframe(self, gtfs_day="19700101"):
-        pass
+    def trips_to_dataframe(self, gtfs_day: str = "19700101") -> pd.DataFrame:
+        """Generates a DataFrame holding all the trips IDs,
+        their departure times (in datetime with given GTFS day, if specified in `gtfs_day`) and vehicle IDs, next to the route ID and service ID.
 
-    def trips_headways(self, from_time=None, to_time=None, gtfs_day="19700101"):
+        Check out also `trips_with_stops_to_dataframe` for a more complex version.
+        All trips are expanded over all of their stops, giving scheduled timestamps of each trips expected to arrive and leave the stop.
+
+        Args:
+            gtfs_day (str, optional): day used for GTFS when creating the network in YYYYMMDD format. Defaults to "19700101".
+
+        Returns:
+            pd.DataFrame: Trips.
         """
-        Generates a DataFrame holding all the trips IDs, their departure times (in datetime with given GTFS day,
-        if specified in `gtfs_day`) and vehicle IDs, next to the route ID and service ID.
-        Adds two columns: headway and headway_mins by calculating the time difference in ordered trip departures for
-        each unique route.
+
+    @abstractmethod
+    def route(self, route_id: Union[str, int]) -> "Route":
+        """Attempting to extract route from route given an id should yield itself unless index doesn't match.
+
+        Args:
+            route_id (Union[str, int]): ID to extract.
+
+        Raises:
+            IndexError: ID must match self ID.
+
+        Returns:
+            Route: This route.
+        """
+
+    def trips_headways(
+        self,
+        from_time: Optional[str] = None,
+        to_time: Optional[str] = None,
+        gtfs_day: str = "19700101",
+    ) -> pd.DataFrame:
+        """Generates a DataFrame holding all the trips IDs, their departure times and vehicle IDs, next to the route ID and service ID.
+
+        Departure times given in datetime format with given GTFS day, if specified in `gtfs_day`.
+
+        Adds two columns: `headway` and `headway_mins` by calculating the time difference in ordered trip departures for each unique route.
+
         This can also be done for a specific time frame by specifying from_time and to_time (or just one of them).
-        :param from_time: "HH:MM:SS" format, used as lower time bound for subsetting
-        :param to_time: "HH:MM:SS" format, used as upper time bound for subsetting
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :return:
+
+        Args:
+            from_time (Optional[str], optional): "HH:MM:SS" format, used as lower time bound for subsetting. Defaults to None.
+            to_time (Optional[str], optional): "HH:MM:SS" format, used as upper time bound for subsetting. Defaults to None.
+            gtfs_day (str, optional): day used for GTFS when creating the network in YYYYMMDD format. Defaults to "19700101".
+
+        Returns:
+            pd.DataFrame: Departure and headway times.
         """
         df = (
             self.trips_to_dataframe(gtfs_day=gtfs_day)
@@ -432,14 +571,23 @@ class ScheduleElement:
 
         return df
 
-    def headway_stats(self, from_time=None, to_time=None, gtfs_day="19700101"):
+    def headway_stats(
+        self,
+        from_time: Optional[str] = None,
+        to_time: Optional[str] = None,
+        gtfs_day: str = "19700101",
+    ) -> pd.DataFrame:
         """
         Generates a DataFrame calculating mean headway in minutes for all routes, with their service ID.
         This can also be done for a specific time frame by specifying from_time and to_time (or just one of them).
-        :param from_time: "HH:MM:SS" format, used as lower time bound for subsetting
-        :param to_time: "HH:MM:SS" format, used as upper time bound for subsetting
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :return:
+
+        Args:
+            from_time (Optional[str], optional): "HH:MM:SS" format, used as lower time bound for subsetting. Defaults to None.
+            to_time (Optional[str], optional): "HH:MM:SS" format, used as upper time bound for subsetting. Defaults to None.
+            gtfs_day (str, optional): day used for GTFS when creating the network in YYYYMMDD format. Defaults to "19700101".
+
+        Returns:
+            pd.DataFrame: Headway stats.
         """
         df = self.trips_headways(from_time=from_time, to_time=to_time, gtfs_day=gtfs_day)
 
@@ -465,10 +613,11 @@ class ScheduleElement:
             )
         return df
 
-    def to_geodataframe(self):
-        """
-        Generates GeoDataFrames of the Schedule graph in Schedule's crs
-        :return: dict with keys 'nodes' and 'links', values are the GeoDataFrames corresponding to nodes and edges
+    def to_geodataframe(self) -> dict[str, gpd.GeoDataFrame]:
+        """Generates GeoDataFrames of the Schedule graph in Schedule's crs.
+
+        Returns:
+            dict[str, gpd.GeoDataFrame]: dict with keys 'nodes' and 'links', values are the GeoDataFrames corresponding to nodes and edges
         """
         return gngeojson.generate_geodataframes(self.graph())
 
@@ -496,35 +645,32 @@ class ScheduleElement:
 
 
 class Stop:
-    """
-    A transit stop that features in a Route object
-
-    Required Parameters
-    ----------
-    :param id: unique identifier
-    :param x: x coordinate or lat if using 'epsg:4326'
-    :param y: y coordinate or lon if using 'epsg:4326'
-    :param epsg: 'epsg:12345'
-
-    Optional Parameters
-    ----------
-    :param transformer: pyproj.Transformer.from_crs(epsg, 'epsg:4326', always_xy=True) optional but makes things MUCH
-    faster if you're reading through a lot of stops in the same projection, all stops are mapped back to 'epsg:4326'
-    and indexed with s2sphere
-    :param name: human readable name for the stop
-    :param kwargs: additional attributes
-    """
-
     def __init__(
         self,
         id: Union[str, int],
         x: Union[str, int, float],
         y: Union[str, int, float],
         epsg: str,
-        transformer: Transformer = None,
+        transformer: Optional[Transformer] = None,
         name: str = "",
         **kwargs,
     ):
+        """A transit stop that features in a Route object.
+
+        Args:
+            id (Union[str, int]): Unique identifier.
+            x (Union[str, int, float]): x coordinate or lat if using 'epsg:4326'.
+            y (Union[str, int, float]): y coordinate or lon if using 'epsg:4326'.
+            epsg (str): Projection, e.g. "epsg:4326".
+            transformer (Optional[Transformer], optional):
+                E.g., result of pyproj.Transformer.from_crs(epsg, 'epsg:4326', always_xy=True).
+                Optional but makes things MUCH faster if you're reading through a lot of stops in the same projection,
+                 all stops are mapped back to 'epsg:4326' and indexed with s2sphere.
+                 Defaults to None.
+            name (str, optional): human readable name for the stop. Defaults to "".
+
+        Keyword Args: Additional attributes which will be attached to the class.
+        """
         self.id = id
         self.x = float(x)
         self.y = float(y)
@@ -586,12 +732,19 @@ class Stop:
                 self.__class__.__name__, self.id, self.epsg, self._round_lat(), self._round_lon()
             )
 
-    def reproject(self, new_epsg, transformer: Transformer = None):
-        """
-        Changes projection of a stop. If doing many stops, it's much quicker to pass the transformer as well as epsg.
-        :param new_epsg: 'epsg:12345'
-        :param transformer:
-        :return:
+    def reproject(self, new_epsg: str, transformer: Optional[Transformer] = None):
+        """Changes projection of a stop.
+
+        If doing many stops, it's much quicker to pass the transformer as well as epsg.
+
+        Args:
+            new_epsg (str):
+                New projection, e.g., "epsg:1234".
+            transformer (Optional[Transformer], optional):
+                E.g., result of pyproj.Transformer.from_crs(epsg, 'epsg:4326', always_xy=True).
+                Optional but makes things MUCH faster if you're reading through a lot of stops in the same projection,
+                 all stops are mapped back to 'epsg:4326' and indexed with s2sphere.
+                 Defaults to None.
         """
         if transformer is None:
             transformer = Transformer.from_crs(self.epsg, new_epsg, always_xy=True)
@@ -599,11 +752,12 @@ class Stop:
         self.epsg = new_epsg
 
     def add_additional_attributes(self, attribs: dict):
-        """
-        adds attributes defined by keys of the attribs dictionary with values of the corresponding values
-        ignores keys: 'id', 'x', 'y'
-        :param attribs: the additional attributes {attrribute_name: attribute_value}
-        :return:
+        """Adds attributes defined by keys of the attribs dictionary with values of the corresponding values.
+
+        Ignores keys: 'id', 'x', 'y'.
+
+        Args:
+            attribs (dict): The additional attributes {attrribute_name: attribute_value}
         """
         for k, v in attribs.items():
             if k not in self.__dict__ or (not self.__dict__[k]):
@@ -635,52 +789,61 @@ class Stop:
 
 
 class Route(ScheduleElement):
-    """
-    A Route is an object which contains information about the trips, times and offsets, mode and name of the route which
-    forms a part of a Service.
-
-    Required Parameters
-    ----------
-    :param route_short_name: route's short name
-    :param mode: mode
-    :param arrival_offsets: list of 'HH:MM:SS' temporal offsets for each of the stops_mapping
-    :param departure_offsets: list of 'HH:MM:SS' temporal offsets for each of the stops_mapping
-
-    Optional Parameters (note, not providing some of the parameters may result in the object failing validation)
-    ----------
-    :param trips: Provide either detailed trip information of headway specification
-    dictionary with keys: 'trip_id', 'trip_departure_time', 'vehicle_id'. Each value is a list
-    e.g. : {'trip_id': ['trip_1', 'trip_2'],  - IDs of trips, unique within the Route
-            'trip_departure_time': ['HH:MM:SS', 'HH:MM:SS'],  - departure time from first stop for each trip_id
-            'vehicle_id': [veh_1, veh_2]} - vehicle IDs for each trip_id, don't need to be unique
-                (i.e. vehicles can be shared between trips, but it's up to you to make this physically possible)
-    :param headway_spec: dictionary with tuple keys: (from time, to time) and headway values in minutes
-         {('HH:MM:SS', 'HH:MM:SS'): headway_minutes}.
-
-    :param stops: ordered list of Stop class objects or Stop IDs already present in a Schedule, if generating a Route
-        to add
-    :param route_long_name: optional, verbose name for the route if exists
-    :param route: optional, network link_ids traversed by the vehicles in this Route instance
-    :param id: optional, unique identifier for the route if available, if not given, will be generated
-    :param await_departure: optional, list of bools of length stops param, whether to await departure at each stop
-    :param kwargs: additional attributes
-    """
-
     def __init__(
         self,
         route_short_name: str,
         mode: str,
-        arrival_offsets: List[str],
-        departure_offsets: List[str],
-        trips: Dict[str, List[str]] = None,
-        headway_spec: Dict[tuple, int] = None,
-        route: list = None,
+        arrival_offsets: list[str],
+        departure_offsets: list[str],
+        trips: Optional[dict[str, list[str]]] = None,
+        headway_spec: Optional[dict] = None,
+        route: Optional[list] = None,
         route_long_name: str = "",
         id: str = "",
-        await_departure: list = None,
-        stops: List[Union[Stop, str]] = None,
+        await_departure: Optional[list] = None,
+        stops: Optional[list[Union[Stop, str]]] = None,
         **kwargs,
     ):
+        """A Route is an object which contains information about the trips, times and offsets, mode and name of the route which forms a part of a Service.
+
+        !!! note
+            Not providing some of the optional parameters may result in the object failing validation.
+
+        Args:
+            route_short_name (str): route's short name.
+            mode (str):  mode.
+            arrival_offsets (list[str]): list of 'HH:MM:SS' temporal offsets for each of the stops_mapping.
+            departure_offsets (list[str]): list of 'HH:MM:SS' temporal offsets for each of the stops_mapping.
+            trips (Optional[dict[str, list[str]]], optional):
+                Provide either detailed trip information of headway specification dictionary with keys: 'trip_id', 'trip_departure_time', 'vehicle_id'.
+                Each value is a list e.g. :
+                ```python
+                {
+                    'trip_id': ['trip_1', 'trip_2'],  # IDs of trips, unique within the Route
+                    'trip_departure_time': ['HH:MM:SS', 'HH:MM:SS'],  # departure time from first stop for each trip_id
+                    'vehicle_id': [veh_1, veh_2]} # vehicle IDs for each trip_id, don't need to be unique (i.e. vehicles can be shared between trips, but it's up to you to make this physically possible).
+                }
+                ```
+                Defaults to None.
+            headway_spec (Optional[dict], optional):
+                Dictionary with tuple keys: (from time, to time) and headway values in minutes:
+                `{('HH:MM:SS', 'HH:MM:SS'): headway_minutes}`.
+                Defaults to None.
+            route (Optional[list], optional):
+                Network link_ids traversed by the vehicles in this Route instance. Defaults to None.
+            route_long_name (str, optional):
+                Verbose name for the route if exists. Defaults to "".
+            id (str, optional):
+                Unique identifier for the route if available, if not given, will be generated. Defaults to "".
+            await_departure (Optional[list], optional):
+                List of bools of length stops param, whether to await departure at each stop. Defaults to None.
+            stops (Optional[list[Union[Stop, str]]], optional):
+                Ordered list of Stop class objects or Stop IDs already present in a Schedule, if generating a Route to add.
+                Defaults to None.
+
+        Keyword Args: Additional attributes which will be attached to the class.
+
+        """
         self.route_short_name = route_short_name
         self.mode = mode
         self.arrival_offsets = arrival_offsets
@@ -769,7 +932,7 @@ class Route(ScheduleElement):
     def __str__(self):
         return self.info()
 
-    def _build_graph(self, stops: List[Stop]):
+    def _build_graph(self, stops: list[Stop]):
         route_graph = nx.DiGraph(name="Route graph")
         try:
             route_nodes = [(stop.id, stop.__dict__) for stop in stops]
@@ -804,11 +967,14 @@ class Route(ScheduleElement):
     def _index_unique(self, idx):
         return idx not in self._graph.graph["routes"]
 
-    def reindex(self, new_id):
-        """
-        Changes the current index of the object to `new_id`
-        :param new_id: desired value of the new index
-        :return:
+    def reindex(self, new_id: Union[str, int]):
+        """Changes the current index of the object to `new_id`.
+
+        Args:
+            new_id (Union[str, int]): desired value of the new index
+
+        Raises:
+            RouteIndexError: New ID cannot already exist.
         """
         if not self._index_unique(new_id):
             raise RouteIndexError(f"Route of index {new_id} already exists")
@@ -857,32 +1023,18 @@ class Route(ScheduleElement):
             len(self.trips["trip_id"]),
         )
 
-    def plot(self, output_dir="", data=False):
-        """
-        Plots the route on kepler map.
-        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install
-        :param output_dir: output directory for the image, if passed, will save plot to html
-        :param data: Defaults to False, only the geometry and ID will be visible.
-            True will visualise all data on the map (not suitable for large networks)
-            A set of keys e.g. {'name'}
-        :return:
-        """
+    def plot(self, output_dir: str = "", data: Union[bool, set] = False) -> KeplerGl:
         return self.kepler_map(output_dir, f"route_{self.id}_map", data=data)
 
-    def stops(self):
+    def stops(self) -> Iterator["Stop"]:
         """
-        Iterable returns Stop objects in the Route in order of travel
-        :return:
+        Yields:
+            Iterable returns Stop objects in the Route in order of travel
         """
         for s in self.ordered_stops:
             yield self.stop(s)
 
-    def route(self, route_id):
-        """
-        Attempting to extract route from route given an id should yield itself unless index doesnt match
-        :param route_id:
-        :return:
-        """
+    def route(self, route_id: Union[str, int]) -> "Route":
         if route_id == self.id:
             return self
         else:
@@ -894,59 +1046,26 @@ class Route(ScheduleElement):
         """
         yield self
 
-    def service_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        """
-        Generates a pandas.DataFrame object indexed by Service IDs, with attribute data stored for Services under `key`
-        :param keys: list of either a string e.g. 'name', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
-        """
+    def service_attribute_data(
+        self, keys: Union[list, str], index_name: Optional[str] = None
+    ) -> pd.DataFrame:
         raise ServiceIndexError("A Route cannot generate a DataFrame with Services data")
 
-    def route_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        """
-        Generates a pandas.DataFrame object indexed by Route IDs, with attribute data stored for Routes under `key`
-        :param keys: list of either a string e.g. 'mode', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
-        """
+    def route_attribute_data(
+        self, keys: Union[list, str], index_name: Optional[str] = None
+    ) -> pd.DataFrame:
         return graph_operations.build_attribute_dataframe(
             iterator=[(self.id, self.__dict__)], keys=keys, index_name=index_name
         )
 
-    def stop_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        """
-        Generates a pandas.DataFrame object indexed by Stop IDs, with attribute data stored for Stops under `key`
-        :param keys: list of either a string e.g. 'x', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
-        """
+    def stop_attribute_data(
+        self, keys: Union[list, str], index_name: Optional[str] = None
+    ) -> pd.DataFrame:
         return graph_operations.build_attribute_dataframe(
             iterator=[(s.id, s.__dict__) for s in self.stops()], keys=keys, index_name=index_name
         )
 
-    def route_trips_with_stops_to_dataframe(self, gtfs_day="19700101"):
-        """
-        This method exists for backwards compatibility only
-        Please use trips_with_stops_to_dataframe
-        :return:
-        """
-        logging.warning(
-            "`route_trips_with_stops_to_dataframe` method is deprecated and will be replaced by "
-            "`trips_to_dataframe` in later versions."
-        )
-        return self.trips_with_stops_to_dataframe(gtfs_day)
-
-    def trips_with_stops_to_dataframe(self, gtfs_day="19700101"):
-        """
-        Generates a DataFrame holding all the trips, their movements from stop to stop (in datetime with given GTFS day,
-        if specified in `gtfs_day`) and vehicle IDs, next to the route ID and service ID.
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :return:
-        """
+    def trips_with_stops_to_dataframe(self, gtfs_day: str = "19700101") -> pd.DataFrame:
         df = None
         _df = DataFrame(
             {
@@ -988,14 +1107,6 @@ class Route(ScheduleElement):
         return df
 
     def trips_to_dataframe(self, gtfs_day="19700101"):
-        """
-        Generates a DataFrame holding all the trips IDs, their departure times (in datetime with given GTFS day,
-        if specified in `gtfs_day`) and vehicle IDs, next to the route ID and service ID.
-        Check out also `trips_with_stops_to_dataframe` for a more complex version - all trips are expanded
-        over all of their stops, giving scheduled timestamps of each trips expected to arrive and leave the stop.
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :return:
-        """
         df = pd.DataFrame(self.trips)
 
         df["route_id"] = self.id
@@ -1006,12 +1117,14 @@ class Route(ScheduleElement):
         return df
 
     def generate_trips_from_headway(self, headway_spec: dict):
-        """
-        Generates new trips for the route.
+        """Generates new trips for the route.
+
         All newly generated trips get unique vehicles with this method.
-        :param headway_spec: dictionary with tuple keys: (from time, to time) and headway values in minutes
-         {('HH:MM:SS', 'HH:MM:SS'): headway_minutes}.
-        :return:
+
+        Args:
+            headway_spec (dict):
+                dictionary with tuple keys: (from time, to time) and headway values in minutes:
+                `{('HH:MM:SS', 'HH:MM:SS'): headway_minutes}`.
         """
         new_trip_departures = list(generate_trip_departures_from_headway(headway_spec))
         new_trip_departures.sort()
@@ -1071,10 +1184,11 @@ class Route(ScheduleElement):
             return True
         return False
 
-    def has_self_loops(self):
-        """
-        means that there are two consecutive stops that are the same
-        :return:
+    def has_self_loops(self) -> list:
+        """Means that there are two consecutive stops that are the same
+
+        Returns:
+            list: All self-loops.
         """
         return list(nx.nodes_with_selfloops(self.graph()))
 
@@ -1172,21 +1286,22 @@ class Route(ScheduleElement):
 
 
 class Service(ScheduleElement):
-    """
-    A Service is an object containing unique routes pertaining to the same public transit service
+    def __init__(self, id: str, routes: Optional[list[Route]] = None, name: str = "", **kwargs):
+        """A Service is an object containing unique routes pertaining to the same public transit service.
 
-    Required Parameters
-    ----------
-    :param id: unique identifier for the service
+        !!! note
+            Not providing some of the optional parameters may result in the object failing validation.
 
-    Optional Parameters (note, not providing some of the parameters may result in the object failing validation)
-    ----------
-    :param routes: list of Route objects, if the Routes are not uniquely indexed, they will be re-indexed
-    :param name: string, name for the service, if not provided, will inherit the first non-trivial name from routes
-    :param kwargs: additional attributes
-    """
+        Args:
+            id (str): Unique identifier for the service
+            routes (Optional[list[Route]], optional): List of Route objects, if the Routes are not uniquely indexed, they will be re-indexed. Defaults to None.
+            name (str, optional): Name for the service, if not provided, will inherit the first non-trivial name from routes. Defaults to "".
 
-    def __init__(self, id: str, routes: List[Route] = None, name: str = "", **kwargs):
+        Keyword Args: Additional attributes which will be attached to the class.
+
+        Raises:
+            ServiceInitialisationError: `routes` must be a valid graph or a list of Route objects.
+        """
         self.id = id
         # a service inherits a name from the first route in the list (all route names are still accessible via each
         # route object
@@ -1211,7 +1326,7 @@ class Service(ScheduleElement):
             self._graph = self._build_graph(self._ensure_unique_routes(routes))
         else:
             raise ServiceInitialisationError(
-                "You need to pass either a valid `_graph` or a list of Route objects to " "`routes`"
+                "You need to pass either a valid `_graph` or a list of Route objects to `routes`"
             )
         super().__init__()
 
@@ -1260,7 +1375,7 @@ class Service(ScheduleElement):
     def _add_additional_attribute_to_graph(self, k, v):
         self._graph.graph["services"][self.id][k] = v
 
-    def _ensure_unique_routes(self, routes: List[Route]):
+    def _ensure_unique_routes(self, routes: list[Route]):
         unique_routes = []
         route_ids = []
         for route in routes:
@@ -1282,16 +1397,21 @@ class Service(ScheduleElement):
     def reference_edges(self):
         return self.service_reference_edges(self.id)
 
-    def split_by_direction(self):
-        """
-        Divide the routes of the Service by direction e.g. North- and Southbound. Depending on the mode,
-        typically a Service will have either 1 or 2 directions. Some Services will have more, especially ones that
-        are loops.
-        :return: Dictionary with directions as keys and lists of routes which head in that direction as values. E.g.:
-        {
-            North-East Bound: ['route_1', 'route_2'],
-            South-West Bound: ['route_3', 'route_4']
-        }
+    def split_by_direction(self) -> dict:
+        """Divide the routes of the Service by direction e.g. North- and South-bound.
+
+        Depending on the mode, typically a Service will have either 1 or 2 directions.
+        Some Services will have more, especially ones that are loops.
+
+        Returns:
+            dict:
+                Dictionary with directions as keys and lists of routes which head in that direction as values. E.g.:
+                ```python
+                {
+                    "North-East Bound": ['route_1', 'route_2'],
+                    "South-West Bound": ['route_3', 'route_4']
+                }
+                ```
         """
         geodesic = Geod(ellps="WGS84")
         route_direction_map = {}
@@ -1311,17 +1431,21 @@ class Service(ScheduleElement):
             res[val].append(key)
         return dict(res)
 
-    def split_graph(self):
-        """
-        Divide the routes and the graph of the Service by share of Service's graph. Most services with have one or two
-        outputs, but some will have more. The results of this method may vary from `split_by_direction`. The output
-        graph edges in the list will be independent of each other (the edges will be independent, but they may share
-        nodes), sometimes producing more than two sets.
-        The method is not symmetric, if the Routes in a Service are listed in a different order this may lead to some
-        graph groups merging (in a desired way).
-        :return: tuple (routes, graph_groups) where routes is a list of sets with grouped route IDs and graph_groups
-            is a list of the same length as routes, each item is a set of graph edges and corresponds to the item in
-            routes list in that same index
+    def split_graph(self) -> tuple[list, list]:
+        """Divide the routes and the graph of the Service by share of Service's graph.
+
+        Most services with have one or two outputs, but some will have more.
+        The results of this method may vary from `split_by_direction`.
+        The output graph edges in the list will be independent of each other (the edges will be independent, but they may share nodes), sometimes producing more than two sets.
+
+        The method is not symmetric, if the Routes in a Service are listed in a different order this may lead to some graph groups merging (in a desired way).
+
+        Returns:
+            tuple[list, list]:
+                (routes, graph_groups) where:
+                - routes is a list of sets with grouped route IDs
+                - graph_groups is a list of the same length as routes.
+                Each item is a set of graph edges and corresponds to the item in routes list in that same index.
         """
 
         def route_overlap_condition(graph_edge_group):
@@ -1387,11 +1511,14 @@ class Service(ScheduleElement):
     def _index_unique(self, idx):
         return idx not in self._graph.graph["services"]
 
-    def reindex(self, new_id):
-        """
-        Changes the current index of the object to `new_id`
-        :param new_id: desired value of the new index
-        :return:
+    def reindex(self, new_id: Union[str, int]):
+        """Changes the current index of the object to `new_id`.
+
+        Args:
+            new_id (Union[str, int]): Desired value of the new index
+
+        Raises:
+            ServiceIndexError: Cannot reindex to an existing ID.
         """
         if not self._index_unique(new_id):
             raise ServiceIndexError(f"Service of index {new_id} already exists")
@@ -1433,75 +1560,29 @@ class Service(ScheduleElement):
             self.__class__.__name__, self.id, self.name, len(self), len(self.reference_nodes())
         )
 
-    def plot(self, output_dir="", data=False):
-        """
-        Plots the service on kepler map.
-        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install
-        :param output_dir: output directory for the image, if passed, will save plot to html
-        :param data: Defaults to False, only the geometry and ID will be visible.
-            True will visualise all data on the map (not suitable for large networks)
-            A set of keys e.g. {'name'}
-        :return:
-        """
+    def plot(self, output_dir: str = "", data: Union[bool, set] = False) -> KeplerGl:
         return self.kepler_map(output_dir, f"service_{self.id}_map", data=data)
 
-    def service_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        """
-        Generates a pandas.DataFrame object indexed by Service IDs, with attribute data stored for Services under `key`
-        :param keys: list of either a string e.g. 'name', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
-        """
+    def service_attribute_data(
+        self, keys: Union[list, str], index_name: Optional[str] = None
+    ) -> pd.DataFrame:
         return graph_operations.build_attribute_dataframe(
             iterator=[(self.id, self.__dict__)], keys=keys, index_name=index_name
         )
 
-    def route_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        """
-        Generates a pandas.DataFrame object indexed by Route IDs, with attribute data stored for Routes under `key`
-        :param keys: list of either a string e.g. 'mode', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
-        """
+    def route_attribute_data(self, keys: Union[list, str], index_name: Optional[str] = None):
         return graph_operations.build_attribute_dataframe(
             iterator=[(rid, self._graph.graph["routes"][rid]) for rid in self.route_ids()],
             keys=keys,
             index_name=index_name,
         )
 
-    def stop_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        """
-        Generates a pandas.DataFrame object indexed by Stop IDs, with attribute data stored for Stops under `key`
-        :param keys: list of either a string e.g. 'x', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
-        """
+    def stop_attribute_data(self, keys: Union[list, str], index_name: Optional[str] = None):
         return graph_operations.build_attribute_dataframe(
             iterator=[(s.id, s.__dict__) for s in self.stops()], keys=keys, index_name=index_name
         )
 
-    def route_trips_with_stops_to_dataframe(self, gtfs_day="19700101"):
-        """
-        This method exists for backwards compatibility only
-        Please use trips_with_stops_to_dataframe
-        :return:
-        """
-        logging.warning(
-            "`route_trips_with_stops_to_dataframe` method is deprecated and will be replaced by "
-            "`trips_to_dataframe` in later versions."
-        )
-        return self.trips_with_stops_to_dataframe(gtfs_day)
-
-    def trips_with_stops_to_dataframe(self, gtfs_day="19700101"):
-        """
-        Generates a DataFrame holding all the trips, their movements from stop to stop (in datetime with given GTFS day,
-        if specified in `gtfs_day`) and vehicle IDs, next to the route ID and service ID.
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :return:
-        """
+    def trips_with_stops_to_dataframe(self, gtfs_day: str = "19700101") -> pd.DataFrame:
         df = None
         for route in self.routes():
             _df = route.trips_with_stops_to_dataframe(gtfs_day=gtfs_day)
@@ -1514,15 +1595,7 @@ class Service(ScheduleElement):
         df = df.reset_index(drop=True)
         return df
 
-    def trips_to_dataframe(self, gtfs_day="19700101"):
-        """
-        Generates a DataFrame holding all the trips IDs, their departure times (in datetime with given GTFS day,
-        if specified in `gtfs_day`) and vehicle IDs, next to the route ID and service ID.
-        Check out also `trips_with_stops_to_dataframe` for a more complex version - all trips are expanded
-        over all of their stops, giving scheduled timestamps of each trips expected to arrive and leave the stop.
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :return:
-        """
+    def trips_to_dataframe(self, gtfs_day: str = "19700101") -> pd.DataFrame:
         df = None
         for route in self.routes():
             _df = route.trips_to_dataframe(gtfs_day=gtfs_day)
@@ -1534,12 +1607,7 @@ class Service(ScheduleElement):
         df = df.reset_index(drop=True)
         return df
 
-    def route(self, route_id):
-        """
-        Extract particular route from a Service given index
-        :param route_id:
-        :return:
-        """
+    def route(self, route_id: Union[str, int]) -> "Route":
         return self._get_route_from_graph(route_id)
 
     def route_ids(self):
@@ -1599,46 +1667,50 @@ class Service(ScheduleElement):
 
 
 class Schedule(ScheduleElement):
-    """
-    Class to provide methods and structure for transit schedules
-
-    Optional Parameters
-    ----------
-    :param epsg: 'epsg:12345', projection for the schedule (each stop has its own epsg)
-    :param services: list of Service class objects
-    :param _graph: Schedule graph, used for re-instantiating the object, passed without `services`
-    :param minimal_transfer_times: {'stop_id_1': {'stop_id_2': 0.0}} seconds_to_transfer between stop_id_1 and
-        stop_id_2
-    :param vehicles: dictionary of vehicle IDs from Route objects, mapping them to vehicle types in vehicle_types.
-        Looks like this: {veh_id : {'type': 'bus'}}
-        Defaults to None and generates itself from the vehicles IDs in Routes, maps to the mode of the Route.
-        Checks if those modes are defined in the vehicle_types.
-    :param vehicle_types: yml file based on `genet/configs/vehicles/vehicle_definitions.yml` or dictionary of vehicle
-        types and their specification. Indexed by the vehicle type that vehicles in the `vehicles` attribute are
-         referring to.
-            {'bus' : {
-                'capacity': {'seats': {'persons': '70'}, 'standingRoom': {'persons': '0'}},
-                'length': {'meter': '18.0'},
-                'width': {'meter': '2.5'},
-                'accessTime': {'secondsPerPerson': '0.5'},
-                'egressTime': {'secondsPerPerson': '0.5'},
-                'doorOperation': {'mode': 'serial'},
-                'passengerCarEquivalents': {'pce': '2.8'}}}
-        Defaults to reading `genet/configs/vehicles/vehicle_definitions.yml`
-    """
-
     def __init__(
         self,
         epsg: str = "",
-        services: List[Service] = None,
-        _graph: nx.DiGraph = None,
-        minimal_transfer_times: Dict[str, Dict[str, float]] = None,
-        vehicles=None,
+        services: Optional[list[Service]] = None,
+        _graph: Optional[nx.DiGraph] = None,
+        minimal_transfer_times: Optional[dict[str, dict[str, float]]] = None,
+        vehicles: Optional[dict] = None,
         vehicle_types: Union[str, dict] = (
             importlib_resources.files("genet") / "configs" / "vehicles" / "vehicle_definitions.yml"
         ).as_posix(),
         **kwargs,
     ):
+        """Class to provide methods and structure for transit schedules.
+
+        Args:
+            epsg (str, optional): Projection for the schedule (each stop has its own epsg), e.g. 'epsg:4326'. Defaults to "".
+            services (Optional[list[Service]], optional): list of Service class objects. Defaults to None.
+            _graph (Optional[nx.DiGraph], optional): Schedule graph, used for re-instantiating the object, passed without `services`. Defaults to None.
+            minimal_transfer_times (Optional[dict[str, dict[str, float]]], optional):
+                Seconds to transfer between `stop_id_1` and `stop_id_2`, e.g.: `{'stop_id_1': {'stop_id_2': 0.0}}`.
+                Defaults to None.
+            vehicles (Optional[dict], optional):
+                Dictionary of vehicle IDs from Route objects, mapping them to vehicle types in vehicle_types.
+                Looks like this: `{veh_id : {'type': 'bus'}}`.
+                Defaults to None and generates itself from the vehicles IDs in Routes, maps to the mode of the Route.
+                Checks if those modes are defined in the vehicle_types.
+            vehicle_types (Union[str, dict], optional):
+                YAML file based on `genet/configs/vehicles/vehicle_definitions.yml` or dictionary of vehicle types and their specification.
+                Indexed by the vehicle type that vehicles in the `vehicles` attribute are referring to.
+                ```python
+                {'bus' : {
+                    'capacity': {'seats': {'persons': '70'}, 'standingRoom': {'persons': '0'}},
+                    'length': {'meter': '18.0'},
+                    'width': {'meter': '2.5'},
+                    'accessTime': {'secondsPerPerson': '0.5'},
+                    'egressTime': {'secondsPerPerson': '0.5'},
+                    'doorOperation': {'mode': 'serial'},
+                    'passengerCarEquivalents': {'pce': '2.8'}}}
+                ```
+                Defaults to reading `genet/configs/vehicles/vehicle_definitions.yml`.
+
+        Raises:
+            UndefinedCoordinateSystemError: A coordinate reference system must be defined by `epsg` or within `_graph`.
+        """
         if isinstance(vehicle_types, dict):
             self.vehicle_types = vehicle_types
         else:
@@ -1769,15 +1841,21 @@ class Schedule(ScheduleElement):
         schedule_graph.graph["services"] = graph_services
         return schedule_graph
 
-    def generate_vehicles(self, overwrite=False):
-        """
-        Generate vehicles for the Schedule. Returns dictionary of vehicle IDs from Route objects, mapping them to
-        vehicle types in vehicle_types. Looks like this:
-            {veh_id : {'type': 'bus'}}
+    def generate_vehicles(self, overwrite: bool = False):
+        """Generate vehicles for the Schedule.
+
+        Returns dictionary of vehicle IDs from Route objects, mapping them to vehicle types in vehicle_types.
+        Looks like this: `{veh_id : {'type': 'bus'}}`.
         Generates itself from the vehicles IDs which exist in Routes, maps to the mode of the Route.
-        :param overwrite: False by default. If False, does not overwrite the types of vehicles currently in the schedule
-            If True, generates completely new vehicle types for all vehicles in the schedule based on Route modes
-        :return:
+
+        Args:
+            overwrite (bool, optional):
+                If False, does not overwrite the types of vehicles currently in the schedule.
+                If True, generates completely new vehicle types for all vehicles in the schedule based on Route modes.
+                Defaults to False.
+
+        Raises:
+            InconsistentVehicleModeError: There should be no modal inconsistencies between vehicles and schedules.
         """
         if self:
             # generate vehicles using Services and Routes upon init
@@ -1802,13 +1880,16 @@ class Schedule(ScheduleElement):
             else:
                 self.vehicles = {**df.T.to_dict(), **self.vehicles}
 
-    def scale_vehicle_capacity(self, capacity_scale, pce_scale, output_dir):
-        """
-        This method scales the vehicle capacities and pce to user defined scales and writes a new vehicle.xml.
-        :param capacity_scale: vehicle capacity scale (float)
-        :param pce_scale: passenger car equivalents scale (float)
-        :return:
-        :example invocation for 5%: scale_vehicle_capacity(0.05, 0.05,"")
+    def scale_vehicle_capacity(self, capacity_scale: float, pce_scale: float, output_dir: str):
+        """This method scales the vehicle capacities and pce to user defined scales and writes a new vehicle.xml.
+
+        Args:
+            capacity_scale (float): vehicle capacity scale
+            pce_scale (float):  passenger car equivalents scale
+            output_dir (str): Directory to save `vehicle.xml`
+
+        Example:
+            For 5%: `!#python scale_vehicle_capacity(0.05, 0.05,"")`
         """
         # save copy of existing vehicle data
         vehicle_types_dict = deepcopy(self.vehicle_types)
@@ -1841,27 +1922,7 @@ class Schedule(ScheduleElement):
             f"{int(pce_scale * 100)}% pce."
         )
 
-    def route_trips_to_dataframe(self, gtfs_day="19700101"):
-        """
-        This method exists for backwards compatibility only
-        Please use trips_to_dataframe
-        :return:
-        """
-        logging.warning(
-            "`route_trips_to_dataframe` method is deprecated and will be replaced by `trips_to_dataframe`"
-            "in later versions."
-        )
-        return self.trips_to_dataframe(gtfs_day)
-
-    def trips_to_dataframe(self, gtfs_day="19700101"):
-        """
-        Generates a DataFrame holding all the trips IDs, their departure times (in datetime with given GTFS day,
-        if specified in `gtfs_day`) and vehicle IDs, next to the route ID and service ID.
-        Check out also `trips_with_stops_to_dataframe` for a more complex version - all trips are expanded
-        over all of their stops, giving scheduled timestamps of each trips expected to arrive and leave the stop.
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :return:
-        """
+    def trips_to_dataframe(self, gtfs_day: str = "19700101") -> pd.DataFrame:
         df = self.route_attribute_data(
             keys=[{"trips": "trip_id"}, {"trips": "trip_departure_time"}, {"trips": "vehicle_id"}],
             index_name="route_id",
@@ -1893,16 +1954,24 @@ class Schedule(ScheduleElement):
         )
         return df
 
-    def generate_trips_dataframe_from_headway(self, route_id, headway_spec: dict):
-        """
-        Generates new trips and vehicles for the specified route.
-        Inherits one of the existing vehicle types - if the vehicle types vary for a route, you will
-        need to generate your own trips dataframe and add those vehicles yourself.
+    def generate_trips_dataframe_from_headway(
+        self, route_id: Union[str, int], headway_spec: dict
+    ) -> pd.DataFrame:
+        """Generates new trips and vehicles for the specified route.
+
+        Inherits one of the existing vehicle types.
+        If the vehicle types vary for a route, you will need to generate your own trips dataframe and add those vehicles yourself.
+
         All newly generated trips get unique vehicles with this method.
-        :param route_id: existing route
-        :param headway_spec: dictionary with tuple keys: (from time, to time) and headway values in minutes
-         {('HH:MM:SS', 'HH:MM:SS'): headway_minutes}.
-        :return:
+
+        Args:
+            route_id (Union[str, int]): existing route
+            headway_spec (dict):
+                dictionary with tuple keys: (from time, to time) and headway values in minutes:
+                `{('HH:MM:SS', 'HH:MM:SS'): headway_minutes}`.
+
+        Returns:
+            pd.DataFrame: Trips.
         """
         veh_type = self.vehicles[self.route(route_id).trips["vehicle_id"][0]]
         new_trip_departures = list(generate_trip_departures_from_headway(headway_spec))
@@ -1922,16 +1991,19 @@ class Schedule(ScheduleElement):
         new_trips["service_id"] = self._graph.graph["route_to_service_map"][route_id]
         return new_trips
 
-    def generate_trips_from_headway(self, route_id, headway_spec: dict):
-        """
-        Generates new trips and vehicles for the specified route.
-        Inherits one of the existing vehicle types - if the vehicle types vary for a route, you will
-        need to generate your own trips dataframe and add those vehicles yourself.
+    def generate_trips_from_headway(self, route_id: Union[str, int], headway_spec: dict):
+        """Generates new trips and vehicles for the specified route.
+
+        Inherits one of the existing vehicle type.
+        If the vehicle types vary for a route, you will need to generate your own trips dataframe and add those vehicles yourself.
+
         All newly generated trips get unique vehicles with this method.
-        :param route_id: existing route
-        :param headway_spec: dictionary with tuple keys: (from time, to time) and headway values in minutes
-         {('HH:MM:SS', 'HH:MM:SS'): headway_minutes}.
-        :return:
+
+        Args:
+            route_id (Union[str, int]): existing route
+            headway_spec (dict):
+                dictionary with tuple keys: (from time, to time) and headway values in minutes:
+                `{('HH:MM:SS', 'HH:MM:SS'): headway_minutes}`.
         """
         veh_type = self.vehicles[self.route(route_id).trips["vehicle_id"][0]]
         old_vehicles = set(self.route(route_id).trips["vehicle_id"])
@@ -2018,14 +2090,15 @@ class Schedule(ScheduleElement):
         )
         return self.set_trips_dataframe(df)
 
-    def set_trips_dataframe(self, df):
-        """
-        Option to replace trips data currently stored under routes by an updated `trips_to_dataframe`.
+    def set_trips_dataframe(self, df: pd.DataFrame):
+        """Option to replace trips data currently stored under routes by an updated `trips_to_dataframe`.
+
         Need not be exhaustive in terms of routes. I.e. trips for some of the routes can be omitted if no changes are
         required. Needs to be exhaustive in terms of trips. I.e. if there are changes to a route, all of the trips
         required to be in that trip need to be present, it overwrites route.trips attribute.
-        :param df: DataFrame generated by `trips_to_dataframe` (or of the same format)
-        :return:
+
+        Args:
+            df (pd.DataFrame): generated by `trips_to_dataframe` (or of the same format)
         """
         # convert route trips dataframe to apply dictionary shape and give to apply to routes method
         df["trip_departure_time"] = df["trip_departure_time"].dt.strftime("%H:%M:%S")
@@ -2040,22 +2113,28 @@ class Schedule(ScheduleElement):
         )
         self.apply_attributes_to_routes(df.T.to_dict())
 
-    def overlapping_vehicle_ids(self, vehicles):
+    def overlapping_vehicle_ids(self, vehicles: dict) -> set:
         return set(self.vehicles.keys()) & set(vehicles.keys())
 
-    def overlapping_vehicle_types(self, vehicle_types):
+    def overlapping_vehicle_types(self, vehicle_types: dict) -> set:
         return set(self.vehicle_types.keys()) & set(vehicle_types.keys())
 
-    def update_vehicles(self, vehicles, vehicle_types, overwrite=True):
-        """
-        Updates vehicles and vehicle types
-        :param vehicles: vehicles to add
-        :param vehicle_types: vehicle types to add
-        :param overwrite: defaults to True
-            If True: overwrites overlapping vehicle types data currently in the Schedule, adds vehicles as they are,
-                overwriting in case of clash
-            If False: adds vehicles and vehicle types that do not clash with those already stored in the Schedule
-        :return:
+    def update_vehicles(
+        self, vehicles: dict, vehicle_types: dict, overwrite: bool = True
+    ) -> tuple[set, set]:
+        """Updates vehicles and vehicle types.
+
+        Args:
+            vehicles (dict): vehicles to add.
+            vehicle_types (dict): vehicle types to add.
+            overwrite (bool, optional):
+                If True: overwrites overlapping vehicle types data currently in the Schedule, adds vehicles as they are,
+                    overwriting in case of clash
+                If False: adds vehicles and vehicle types that do not clash with those already stored in the Schedule.
+                Defaults to True.
+
+        Returns:
+            tuple[set, set]: Any clashing 1. vehicles and 2. vehicle types.
         """
         # check for vehicle ID overlap
         clashing_vehicles = self.overlapping_vehicle_ids(vehicles=vehicles)
@@ -2090,11 +2169,13 @@ class Schedule(ScheduleElement):
         self.validate_vehicle_definitions()
         return clashing_vehicles, clashing_vehicle_types
 
-    def validate_vehicle_definitions(self):
-        """
-        Checks if modes mapped to vehicle IDs in vehicles attribute of Schedule are defined in the vehicle_types.
-        :return: returns True if the vehicle types in the `vehicles` attribute exist in the `vehicle_types` attribute.
-            But useful even just for the logging messages.
+    def validate_vehicle_definitions(self) -> bool:
+        """Checks if modes mapped to vehicle IDs in vehicles attribute of Schedule are defined in the vehicle_types.
+
+        Returns:
+            bool:
+                Returns True if the vehicle types in the `vehicles` attribute exist in the `vehicle_types` attribute.
+                But useful even just for the logging messages.
         """
 
         missing_vehicle_information = self.get_missing_vehicle_information()
@@ -2156,17 +2237,23 @@ class Schedule(ScheduleElement):
         if isinstance(self, Schedule):
             raise NotImplementedError("Schedule is not currently an indexed object")
 
-    def add(self, other, overwrite=True):
-        """
-        Adds another Schedule. They have to be separable! I.e. the keys in services cannot overlap with the ones
-        already present (TODO: add merging complicated schedules, parallels to the merging gtfs work)
-        :param other: the other Schedule object to add
-        :param overwrite: defaults to True
-            If True: overwrites overlapping vehicle types data currently in the Schedule, adds vehicles as they are,
-                overwriting in case of clash
-            If False: adds vehicles and vehicle types from other that do not clash with those already stored in the
-            Schedule
-        :return:
+    def add(self, other: "Schedule", overwrite: bool = True):
+        """Adds another Schedule in-place.
+
+        They have to be separable! I.e. the keys in services cannot overlap with the ones already present.
+
+        TODO: add merging complicated schedules, parallels to the merging gtfs work.
+
+        Args:
+            other (Schedule): the other Schedule object to add
+            overwrite (bool, optional):
+                If True: overwrites overlapping vehicle types data currently in the Schedule, adds vehicles as they are,
+                    overwriting in case of clash
+                If False: adds vehicles and vehicle types from other that do not clash with those already stored in the Schedule.
+                Defaults to True.
+
+        Raises:
+            NotImplementedError: Schedules must not have overlapping services.
         """
         if not self.is_separable_from(other):
             # have left and right indicies
@@ -2222,12 +2309,14 @@ class Schedule(ScheduleElement):
     def graph(self):
         return self._graph
 
-    def reproject(self, new_epsg, processes=1):
-        """
-        Changes projection of the element to new_epsg
-        :param new_epsg: 'epsg:1234'
-        :param processes: integer number of processes to split stops data to be processed in parallel
-        :return:
+    def reproject(self, new_epsg: str, processes: int = 1):
+        """Changes projection of the element to `new_epsg`.
+
+        Args:
+            new_epsg (str):
+                New projection, e.g., "epsg:1234".
+            processes (int, optional):
+                Number of parallel processes to use when reprojecting. Defaults to 1.
         """
         ScheduleElement.reproject(self, new_epsg, processes=processes)
         self._graph.graph["crs"] = new_epsg
@@ -2235,39 +2324,10 @@ class Schedule(ScheduleElement):
     def find_epsg(self):
         return self.init_epsg
 
-    def plot(self, output_dir="", data=False):
-        """
-        Plots the schedule on kepler map.
-        Ensure all prerequisites are installed https://docs.kepler.gl/docs/keplergl-jupyter#install
-        :param output_dir: output directory for the image, if passed, will save plot to html
-        :param data: Defaults to False, only the geometry and ID will be visible.
-            True will visualise all data on the map (not suitable for large networks)
-            A set of keys e.g. {'name'}
-        :return:
-        """
+    def plot(self, output_dir: str = "", data: Union[bool, set] = False) -> KeplerGl:
         return self.kepler_map(output_dir, "schedule_map", data=data)
 
-    def route_trips_with_stops_to_dataframe(self, gtfs_day="19700101"):
-        """
-        This method exists for backwards compatibility only
-        Please use trips_with_stops_to_dataframe
-        :return:
-        """
-        logging.warning(
-            "`route_trips_with_stops_to_dataframe` method is deprecated and will be replaced by "
-            "`trips_to_dataframe` in later versions."
-        )
-        return self.trips_with_stops_to_dataframe(gtfs_day)
-
-    def trips_with_stops_to_dataframe(self, gtfs_day="19700101"):
-        """
-        Generates a DataFrame holding all the trips, their movements from stop to stop (in datetime with given GTFS day,
-        if specified in `gtfs_day`) and vehicle IDs, next to the route ID and service ID.
-        Check out also `trips_to_dataframe` for a simplified version (trips, their departure times and vehicles
-        only)
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :return:
-        """
+    def trips_with_stops_to_dataframe(self, gtfs_day: str = "19700101") -> pd.DataFrame:
         df = self.route_attribute_data(
             keys=[
                 "route_short_name",
@@ -2374,12 +2434,7 @@ class Schedule(ScheduleElement):
         for service_id in self.service_ids():
             yield self._get_service_from_graph(service_id)
 
-    def route(self, route_id):
-        """
-        Gives the Route objects under route_id
-        :param route_id: string
-        :return:
-        """
+    def route(self, route_id: Union[str, int]) -> "Route":
         return self._get_route_from_graph(route_id)
 
     def route_ids(self):
@@ -2410,116 +2465,102 @@ class Schedule(ScheduleElement):
         """
         return self._graph.has_node(stop_id)
 
-    def service_attribute_summary(self, data=False):
-        """
-        Parses through data stored for Services in the Schedule and gives a summary tree.
-        If data is True, shows also up to 5 unique values stored under such keys.
-        :param data: bool, False by default
-        :return:
+    def service_attribute_summary(self, data: bool = False):
+        """Parses through data stored for Services in the Schedule and prints a summary tree.
+
+        Args:
+            data (bool, optional): If True, shows also up to 5 unique values stored under such keys. Defaults to False.
         """
         root = graph_operations.get_attribute_schema(
             self._graph.graph["services"].items(), data=data
         )
         graph_operations.render_tree(root, data)
 
-    def route_attribute_summary(self, data=False):
-        """
-        Parses through data stored for Routes in the Schedule and gives a summary tree.
-        If data is True, shows also up to 5 unique values stored under such keys.
-        :param data: bool, False by default
-        :return:
+    def route_attribute_summary(self, data: bool = False):
+        """Parses through data stored for Routes in the Schedule and gives a summary tree.
+
+        Args:
+            data (bool, optional): If True, shows also up to 5 unique values stored under such keys. Defaults to False.
         """
         root = graph_operations.get_attribute_schema(self._graph.graph["routes"].items(), data=data)
         graph_operations.render_tree(root, data)
 
-    def stop_attribute_summary(self, data=False):
-        """
-        Parses through data stored for Stops in the Schedule and gives a summary tree.
-        If data is True, shows also up to 5 unique values stored under such keys.
-        :param data: bool, False by default
-        :return:
+    def stop_attribute_summary(self, data: bool = False):
+        """Parses through data stored for Stops in the Schedule and gives a summary tree.
+
+        Args:
+            data (bool, optional): If True, shows also up to 5 unique values stored under such keys. Defaults to False.
         """
         root = graph_operations.get_attribute_schema(self._graph.nodes(data=True), data=data)
         graph_operations.render_tree(root, data)
 
-    def service_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        """
-        Generates a pandas.DataFrame object indexed by Service IDs, with attribute data stored for Services under `key`
-        :param keys: list of either a string e.g. 'name', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
-        """
+    def service_attribute_data(
+        self, keys: Union[list, str], index_name: Optional[str] = None
+    ) -> pd.DataFrame:
         return graph_operations.build_attribute_dataframe(
             iterator=self._graph.graph["services"].items(), keys=keys, index_name=index_name
         )
 
-    def route_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        """
-        Generates a pandas.DataFrame object indexed by Route IDs, with attribute data stored for Routes under `key`
-        :param keys: list of either a string e.g. 'mode', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
-        """
+    def route_attribute_data(self, keys: Union[list, str], index_name: Optional[str] = None):
         return graph_operations.build_attribute_dataframe(
             iterator=self._graph.graph["routes"].items(), keys=keys, index_name=index_name
         )
 
-    def stop_attribute_data(self, keys: Union[list, str], index_name: str = None):
-        """
-        Generates a pandas.DataFrame object indexed by Stop IDs, with attribute data stored for Stops under `key`
-        :param keys: list of either a string e.g. 'x', or if accessing nested information, a dictionary
-            e.g. {'attributes': {'osm:way:name': 'text'}}
-        :param index_name: optional, gives the index_name to dataframes index
-        :return: pandas.DataFrame
-        """
+    def stop_attribute_data(self, keys: Union[list, str], index_name: Optional[str] = None):
         return graph_operations.build_attribute_dataframe(
             iterator=self._graph.nodes(data=True), keys=keys, index_name=index_name
         )
 
     def extract_service_ids_on_attributes(
-        self, conditions: Union[list, dict], how=any, mixed_dtypes=True
-    ):
-        """
-        Extracts IDs of Services stored in the Schedule based on values of their attributes.
-        Fails silently, assumes not all Services have those attributes. In the case were the attributes stored are
-        a list or set, like in the case of a simplified network (there will be a mix of objects that are sets and not)
-        an intersection of values satisfying condition(s) is considered in case of iterable value, if not empty, it is
-        deemed successful by default. To disable this behaviour set mixed_dtypes to False.
-        :param conditions: {'attribute_key': 'target_value'} or nested
-        {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}}, where 'target_value' could be
+        self, conditions: Union[list, dict], how: Callable = any, mixed_dtypes: bool = True
+    ) -> list[str]:
+        """Extracts IDs of Services stored in the Schedule based on values of their attributes.
 
-            - single value, string, int, float, where the edge_data[key] == value
+        Fails silently, assumes not all Services have those attributes.
+
+        In the case were the attributes stored are a list or set,
+        like in the case of a simplified network (there will be a mix of objects that are sets and not),
+        an intersection of values satisfying condition(s) is considered in case of iterable value,
+        if not empty, it is deemed successful by default.
+        To disable this behaviour set mixed_dtypes to False.
+
+        Args:
+            conditions (Union[list, dict]):
+                {'attribute_key': 'target_value'} or nested {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}},
+                where 'target_value' could be:
+
+                - single value, string, int, float, where the edge_data[key] == value
                 (if mixed_dtypes==True and in case of set/list edge_data[key], value is in edge_data[key])
 
-            - list or set of single values as above, where edge_data[key] in [value1, value2]
+                - list or set of single values as above, where edge_data[key] in [value1, value2]
                 (if mixed_dtypes==True and in case of set/list edge_data[key],
                 set(edge_data[key]) & set([value1, value2]) is non-empty)
 
-            - for int or float values, two-tuple bound (lower_bound, upper_bound) where
-              lower_bound <= edge_data[key] <= upper_bound
+                - for int or float values, two-tuple bound (lower_bound, upper_bound) where
+                lower_bound <= edge_data[key] <= upper_bound
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] satisfies lower_bound <= item <= upper_bound)
 
-            - function that returns a boolean given the value e.g.
-
-            def below_exclusive_upper_bound(value):
-                return value < 100
-
+                - function that returns a boolean given the value e.g.
+                ```python
+                def below_exclusive_upper_bound(value):
+                    return value < 100
+                ```
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] returns True after applying function)
 
-        :param how : {all, any}, default any
+            how (Callable, optional):
+                The level of rigour used to match conditions. Defaults to any.
+                - all: means all conditions need to be met
+                - any: means at least one condition needs to be met
 
-        The level of rigour used to match conditions
+            mixed_dtypes (bool, optional):
+                If True, will consider the intersection of single values or lists of values in queried dictionary keys, e.g. as in simplified networks.
+                Defaults to True.
 
-            * all: means all conditions need to be met
-            * any: means at least one condition needs to be met
+        Returns:
+            list[str]: list of ids in the schedule satisfying conditions.
 
-        :param mixed_dtypes: True by default, used if values under dictionary keys queried are single values or lists of
-        values e.g. as in simplified networks.
-        :return: list of ids in the schedule satisfying conditions
         """
         return graph_operations.extract_on_attributes(
             self._graph.graph["services"].items(),
@@ -2529,47 +2570,54 @@ class Schedule(ScheduleElement):
         )
 
     def extract_route_ids_on_attributes(
-        self, conditions: Union[list, dict], how=any, mixed_dtypes=True
-    ):
-        """
-        Extracts IDs of Routes stored in the Schedule based on values of their attributes.
-        Fails silently, assumes not all Routes have those attributes. In the case were the attributes stored are
-        a list or set, like in the case of a simplified network (there will be a mix of objects that are sets and not)
-        an intersection of values satisfying condition(s) is considered in case of iterable value, if not empty, it is
-        deemed successful by default. To disable this behaviour set mixed_dtypes to False.
-        :param conditions: {'attribute_key': 'target_value'} or nested
-        {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}}, where 'target_value' could be
+        self, conditions: Union[list, dict], how: Callable = any, mixed_dtypes: bool = True
+    ) -> list[str]:
+        """Extracts IDs of Routes stored in the Schedule based on values of their attributes.
 
-            - single value, string, int, float, where the edge_data[key] == value
+        Fails silently, assumes not all Routes have those attributes.
+
+        In the case were the attributes stored are a list or set,
+        like in the case of a simplified network (there will be a mix of objects that are sets and not),
+        an intersection of values satisfying condition(s) is considered in case of iterable value,
+        if not empty, it is deemed successful by default.
+        To disable this behaviour set mixed_dtypes to False.
+
+        Args:
+            conditions (Union[list, dict]):
+                {'attribute_key': 'target_value'} or nested {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}},
+                where 'target_value' could be:
+
+                - single value, string, int, float, where the edge_data[key] == value
                 (if mixed_dtypes==True and in case of set/list edge_data[key], value is in edge_data[key])
 
-            - list or set of single values as above, where edge_data[key] in [value1, value2]
+                - list or set of single values as above, where edge_data[key] in [value1, value2]
                 (if mixed_dtypes==True and in case of set/list edge_data[key],
                 set(edge_data[key]) & set([value1, value2]) is non-empty)
 
-            - for int or float values, two-tuple bound (lower_bound, upper_bound) where
-              lower_bound <= edge_data[key] <= upper_bound
+                - for int or float values, two-tuple bound (lower_bound, upper_bound) where
+                lower_bound <= edge_data[key] <= upper_bound
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] satisfies lower_bound <= item <= upper_bound)
 
-            - function that returns a boolean given the value e.g.
-
-            def below_exclusive_upper_bound(value):
-                return value < 100
-
+                - function that returns a boolean given the value e.g.
+                ```python
+                def below_exclusive_upper_bound(value):
+                    return value < 100
+                ```
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] returns True after applying function)
 
-        :param how : {all, any}, default any
+            how (Callable, optional):
+                The level of rigour used to match conditions. Defaults to any.
+                - all: means all conditions need to be met
+                - any: means at least one condition needs to be met
 
-        The level of rigour used to match conditions
+            mixed_dtypes (bool, optional):
+                If True, will consider the intersection of single values or lists of values in queried dictionary keys, e.g. as in simplified networks.
+                Defaults to True.
 
-            * all: means all conditions need to be met
-            * any: means at least one condition needs to be met
-
-        :param mixed_dtypes: True by default, used if values under dictionary keys queried are single values or lists of
-        values e.g. as in simplified networks.
-        :return: list of ids in the schedule satisfying conditions
+        Returns:
+            list[str]: list of ids in the schedule satisfying conditions.
         """
         return graph_operations.extract_on_attributes(
             self._graph.graph["routes"].items(),
@@ -2579,85 +2627,106 @@ class Schedule(ScheduleElement):
         )
 
     def extract_stop_ids_on_attributes(
-        self, conditions: Union[list, dict], how=any, mixed_dtypes=True
-    ):
-        """
-        Extracts IDs of Stops stored in the Schedule based on values of their attributes.
-        Fails silently, assumes not all Routes have those attributes. In the case were the attributes stored are
-        a list or set, like in the case of a simplified network (there will be a mix of objects that are sets and not)
-        an intersection of values satisfying condition(s) is considered in case of iterable value, if not empty, it is
-        deemed successful by default. To disable this behaviour set mixed_dtypes to False.
-        :param conditions: {'attribute_key': 'target_value'} or nested
-        {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}}, where 'target_value' could be
+        self, conditions: Union[list, dict], how: Callable = any, mixed_dtypes: bool = True
+    ) -> list[str]:
+        """Extracts IDs of Stops stored in the Schedule based on values of their attributes.
 
-            - single value, string, int, float, where the edge_data[key] == value
+        Fails silently, assumes not all Routes have those attributes.
+
+        In the case were the attributes stored are a list or set,
+        like in the case of a simplified network (there will be a mix of objects that are sets and not),
+        an intersection of values satisfying condition(s) is considered in case of iterable value,
+        if not empty, it is deemed successful by default.
+        To disable this behaviour set mixed_dtypes to False.
+
+        Args:
+            conditions (Union[list, dict]):
+                {'attribute_key': 'target_value'} or nested {'attribute_key': {'another_key': {'yet_another_key': 'target_value'}}},
+                where 'target_value' could be:
+
+                - single value, string, int, float, where the edge_data[key] == value
                 (if mixed_dtypes==True and in case of set/list edge_data[key], value is in edge_data[key])
 
-            - list or set of single values as above, where edge_data[key] in [value1, value2]
+                - list or set of single values as above, where edge_data[key] in [value1, value2]
                 (if mixed_dtypes==True and in case of set/list edge_data[key],
                 set(edge_data[key]) & set([value1, value2]) is non-empty)
 
-            - for int or float values, two-tuple bound (lower_bound, upper_bound) where
-              lower_bound <= edge_data[key] <= upper_bound
+                - for int or float values, two-tuple bound (lower_bound, upper_bound) where
+                lower_bound <= edge_data[key] <= upper_bound
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] satisfies lower_bound <= item <= upper_bound)
 
-            - function that returns a boolean given the value e.g.
-
-            def below_exclusive_upper_bound(value):
-                return value < 100
-
+                - function that returns a boolean given the value e.g.
+                ```python
+                def below_exclusive_upper_bound(value):
+                    return value < 100
+                ```
                 (if mixed_dtypes==True and in case of set/list edge_data[key], at least one item in
                 edge_data[key] returns True after applying function)
 
-        :param how : {all, any}, default any
+            how (Callable, optional):
+                The level of rigour used to match conditions. Defaults to any.
+                - all: means all conditions need to be met
+                - any: means at least one condition needs to be met
 
-        The level of rigour used to match conditions
+            mixed_dtypes (bool, optional):
+                If True, will consider the intersection of single values or lists of values in queried dictionary keys, e.g. as in simplified networks.
+                Defaults to True.
 
-            * all: means all conditions need to be met
-            * any: means at least one condition needs to be met
-
-        :param mixed_dtypes: True by default, used if values under dictionary keys queried are single values or lists of
-        values e.g. as in simplified networks.
-        :return: list of ids in the schedule satisfying conditions
+        Returns:
+            list[str]: list of ids in the schedule satisfying conditions.
         """
         return graph_operations.extract_on_attributes(
             self._graph.nodes(data=True), conditions=conditions, how=how, mixed_dtypes=mixed_dtypes
         )
 
-    def services_on_modal_condition(self, modes: Union[str, list]):
+    def services_on_modal_condition(self, modes: Union[str, list]) -> list:
         """
         Finds Service IDs which hold Routes with modes or singular mode given in `modes`.
         Note that a Service can have Routes with different modes.
-        :param modes: string mode e.g. 'bus' or a list of such modes e.g. ['bus', 'rail']
-        :return: list of Service IDs
+
+        Args:
+            modes (Union[str, list]):  string mode e.g. 'bus' or a list of such modes e.g. ['bus', 'rail'].
+
+        Returns:
+            list: list of Service IDs
         """
         route_ids = self.routes_on_modal_condition(modes=modes)
         return list({self._graph.graph["route_to_service_map"][r_id] for r_id in route_ids})
 
-    def routes_on_modal_condition(self, modes: Union[str, list]):
+    def routes_on_modal_condition(self, modes: Union[str, list]) -> list:
         """
         Finds Route IDs with modes or singular mode given in `modes`
-        :param modes: string mode e.g. 'bus' or a list of such modes e.g. ['bus', 'rail']
-        :return: list of Route IDs
+
+        Args:
+            modes (Union[str, list]):  string mode e.g. 'bus' or a list of such modes e.g. ['bus', 'rail'].
+
+        Returns:
+            list: list of Route IDs
         """
         conditions = {"mode": modes}
         return self.extract_route_ids_on_attributes(conditions=conditions)
 
-    def stops_on_modal_condition(self, modes: Union[str, list]):
+    def stops_on_modal_condition(self, modes: Union[str, list]) -> list:
         """
         Finds Stop IDs used by Routes with modes or singular mode given in `modes`
-        :param modes: string mode e.g. 'bus' or a list of such modes e.g. ['bus', 'rail']
-        :return: list of Stop IDs
+
+        Args:
+            modes (Union[str, list]):  string mode e.g. 'bus' or a list of such modes e.g. ['bus', 'rail'].
+
+        Returns:
+            list: list of Stop IDs
         """
         route_ids = self.routes_on_modal_condition(modes=modes)
         return self.extract_stop_ids_on_attributes(conditions={"routes": route_ids})
 
-    def subschedule(self, service_ids):
-        """
-        Subset a Schedule object using a spatial bound
-        :param service_ids: collection of service IDs in the Schedule for subsetting.
-        :return: A new Schedule object that is a subset of the original
+    def subschedule(self, service_ids: list) -> "Schedule":
+        """Subset a Schedule object using a spatial bound.
+        Args:
+            service_ids (list): Collection of service IDs in the Schedule for subsetting.
+
+        Returns:
+            Schedule: A new Schedule object that is a subset of the original.
         """
         subschedule = self.__copy__()
         for s in subschedule.service_ids():
@@ -2666,39 +2735,39 @@ class Schedule(ScheduleElement):
         subschedule.remove_unused_stops()
         return subschedule
 
-    def subschedule_on_spatial_condition(self, region_input, how="intersect"):
-        """
-        Subset a Schedule object using a spatial bound
-        :param region_input:
-            - path to a geojson file, can have multiple features
-            - string with comma separated hex tokens of Google's S2 geometry, a region can be covered with cells and
-             the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/
-             e.g. '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'
-            - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects
-        :param how:
-            - 'intersect' default, will return IDs of the Services whose at least one Stop intersects the
-            region_input
-            - 'within' will return IDs of the Services whose all of the Stops are contained within the region_input
-        :return: A new Schedule object that is a subset of the original
+    def subschedule_on_spatial_condition(
+        self,
+        region_input: Union[str, BaseGeometry],
+        how: Literal["interact", "within"] = "intersect",
+    ) -> "Schedule":
+        """Subset a Schedule object using a spatial
+
+        Schedule: A new Schedule object that is a subset of the original
         """
         services_to_keep = self.services_on_spatial_condition(region_input=region_input, how=how)
         return self.subschedule(service_ids=services_to_keep)
 
-    def services_on_spatial_condition(self, region_input, how="intersect"):
-        """
-        Returns Service IDs which intersect region_input, by default, or are contained within region_input if
-        how='within'
-        :param region_input:
-            - path to a geojson file, can have multiple features
-            - string with comma separated hex tokens of Google's S2 geometry, a region can be covered with cells and
-             the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/
-             e.g. '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'
-            - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects
-        :param how:
-            - 'intersect' default, will return IDs of the Services whose at least one Stop intersects the
-            region_input
-            - 'within' will return IDs of the Services whose all of the Stops are contained within the region_input
-        :return: Service IDs
+    def services_on_spatial_condition(
+        self,
+        region_input: Union[str, BaseGeometry],
+        how: Literal["interact", "within"] = "intersect",
+    ) -> list:
+        """Returns Service IDs which intersect region_input, by default, or are contained within region_input if how='within'.
+
+        Args:
+            region_input (Union[str, BaseGeometry]):
+                - path to a geojson file, can have multiple features.
+                - string with comma separated hex tokens of Google's S2 geometry.
+                A region can be covered with cells and the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/.
+                E.g., '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'.
+                - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects.
+            how (Literal[intersect, within], optional):
+                Defaults to "intersect".
+                - 'intersect' will return IDs of the Services whose at least one Stop intersects the `region_input`.
+                - 'within' will return IDs of the Services whose all of the Stops are contained within the `region_input`.
+
+        Returns:
+            list: Service IDs
         """
         if how == "intersect":
             stops_intersecting = self.stops_on_spatial_condition(region_input)
@@ -2719,21 +2788,28 @@ class Schedule(ScheduleElement):
         else:
             raise NotImplementedError("Only `intersect` and `within` options for `how` param.")
 
-    def routes_on_spatial_condition(self, region_input, how="intersect"):
+    def routes_on_spatial_condition(
+        self,
+        region_input: Union[str, BaseGeometry],
+        how: Literal["interact", "within"] = "intersect",
+    ) -> list:
         """
-        Returns Route IDs which intersect region_input, by default, or are contained within region_input if
-        how='within'
-        :param region_input:
-            - path to a geojson file, can have multiple features
-            - string with comma separated hex tokens of Google's S2 geometry, a region can be covered with cells and
-             the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/
-             e.g. '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'
-            - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects
-        :param how:
-            - 'intersect' default, will return IDs of the Services whose at least one Stop intersects the
-            region_input
-            - 'within' will return IDs of the Services whose all of the Stops are contained within the region_input
-        :return: Route IDs
+        Returns Route IDs which intersect region_input, by default, or are contained within region_input if how='within'.
+
+        Args:
+            region_input (Union[str, BaseGeometry]):
+                - path to a geojson file, can have multiple features.
+                - string with comma separated hex tokens of Google's S2 geometry.
+                A region can be covered with cells and the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/.
+                E.g., '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'.
+                - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects.
+            how (Literal[intersect, within], optional):
+                Defaults to "intersect".
+                - 'intersect' will return IDs of the Services whose at least one Stop intersects the `region_input`.
+                - 'within' will return IDs of the Services whose all of the Stops are contained within the `region_input`.
+
+        Returns:
+            list: Route IDs
         """
         stops_intersecting = set(self.stops_on_spatial_condition(region_input))
         if how == "intersect":
@@ -2752,16 +2828,19 @@ class Schedule(ScheduleElement):
         else:
             raise NotImplementedError("Only `intersect` and `within` options for `how` param.")
 
-    def stops_on_spatial_condition(self, region_input):
-        """
-        Returns Stop IDs which intersect region_input
-        :param region_input:
-            - path to a geojson file, can have multiple features
-            - string with comma separated hex tokens of Google's S2 geometry, a region can be covered with cells and
-             the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/
-             e.g. '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'
-            - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects
-        :return: Stop IDs
+    def stops_on_spatial_condition(self, region_input: Union[str, BaseGeometry]) -> list:
+        """Returns Stop IDs which intersect region_input.
+
+        Args:
+            region_input (Union[str, BaseGeometry]):
+                - path to a geojson file, can have multiple features.
+                - string with comma separated hex tokens of Google's S2 geometry.
+                A region can be covered with cells and the tokens string copied using http://s2.sidewalklabs.com/regioncoverer/.
+                E.g., '89c25985,89c25987,89c2598c,89c25994,89c25999ffc,89c2599b,89c259ec,89c259f4,89c25a1c,89c25a24'.
+                - shapely.geometry object, e.g. Polygon or a shapely.geometry.GeometryCollection of such objects.
+
+        Returns:
+            list: Stop IDs
         """
         if isinstance(region_input, str):
             if persistence.is_geojson(region_input):
@@ -2799,12 +2878,14 @@ class Schedule(ScheduleElement):
             raise NotImplementedError("Changing id can only be done via the `reindex` method")
 
     def apply_attributes_to_services(self, new_attributes: dict):
-        """
-        Adds, or changes if already present, the attributes in new_attributes. Doesn't replace the dictionary
-        stored for the Services presently, so no data is lost, unless it is being overwritten. Changing IDs this way
-        with result in an error. Use Service's `reindex` method instead.
-        :param new_attributes: keys are Service IDs and values are dictionaries of data to add/replace if present
-        :return:
+        """Adds, or changes if already present, the attributes in new_attributes.
+
+        Doesn't replace the dictionary stored for the Services presently, so no data is lost, unless it is being overwritten.
+        Changing IDs this way with result in an error.
+        Use Service's `reindex` method instead.
+
+        Args:
+            new_attributes (dict): keys are Service IDs and values are dictionaries of data to add/replace if present.
         """
         self._verify_no_id_change(new_attributes)
         services = list(new_attributes.keys())
@@ -2825,12 +2906,14 @@ class Schedule(ScheduleElement):
         logging.info(f"Changed Service attributes for {len(services)} services")
 
     def apply_attributes_to_routes(self, new_attributes: dict):
-        """
-        Adds, or changes if already present, the attributes in new_attributes. Doesn't replace the dictionary
-        stored for the Routes presently, so no data is lost, unless it is being overwritten. Changing IDs this way
-        with result in an error. Use Route's `reindex` method instead.
-        :param new_attributes: keys are Route IDs and values are dictionaries of data to add/replace if present
-        :return:
+        """Adds, or changes if already present, the attributes in new_attributes.
+
+        Doesn't replace the dictionary stored for the Routes presently, so no data is lost, unless it is being overwritten.
+        Changing IDs this way with result in an error.
+        Use Route's `reindex` method instead.
+
+        Args:
+            new_attributes (dict): keys are Service IDs and values are dictionaries of data to add/replace if present.
         """
         self._verify_no_id_change(new_attributes)
         # check for stop changes
@@ -2880,12 +2963,14 @@ class Schedule(ScheduleElement):
         logging.info(f"Changed Route attributes for {len(routes)} routes")
 
     def apply_attributes_to_stops(self, new_attributes: dict):
-        """
-        Adds, or changes if already present, the attributes in new_attributes. Doesn't replace the dictionary
-        stored for the Stops presently, so no data is lost, unless it is being overwritten. Changing IDs this way
-        with result in an error. Use Stop's `reindex` method instead.
-        :param new_attributes: keys are Stop IDs and values are dictionaries of data to add/replace if present
-        :return:
+        """Adds, or changes if already present, the attributes in new_attributes.
+
+        Doesn't replace the dictionary stored for the Stops presently, so no data is lost, unless it is being overwritten.
+        Changing IDs this way with result in an error.
+        Use Stop's `reindex` method instead.
+
+        Args:
+            new_attributes (dict): keys are Service IDs and values are dictionaries of data to add/replace if present.
         """
         self._verify_no_id_change(new_attributes)
         stops = list(new_attributes.keys())
@@ -2902,45 +2987,54 @@ class Schedule(ScheduleElement):
         nx.set_node_attributes(self._graph, dict(zip(stops, new_attribs)))
         logging.info(f"Changed Stop attributes for {len(stops)} stops")
 
-    def apply_function_to_services(self, function, location: str):
-        """
-        Applies a function or mapping to Services within the Schedule. Fails silently, if the keys referred to by the
-        function are not present, they will not be considered. The function will only be applied where it is possible.
-        :param function: function, a callable, of Service attributes dictionary returning a value that should be stored
-            under `location` or a dictionary mapping - in the case of a dictionary all values stored under `location`
-            will be mapped to new values given by the mapping, if they are present.
-        :param location: where to save the results: string defining the key in the Service attributes dictionary
-        :return:
+    def apply_function_to_services(self, function: Callable, location: str):
+        """Applies a function or mapping to Services within the Schedule.
+
+        Fails silently, if the keys referred to by the function are not present, they will not be considered.
+        The function will only be applied where it is possible.
+
+        Args:
+            function (Callable):
+                Function of Service attributes dictionary returning a value that should be stored under `location` or a dictionary mapping.
+                In the case of a dictionary all values stored under `location` will be mapped to new values given by the mapping, if they are present.
+
+            location (str): where to save the results: string defining the key in the Service attributes dictionary
         """
         new_attributes = graph_operations.apply_to_attributes(
             self._graph.graph["services"].items(), function, location
         )
         self.apply_attributes_to_services(new_attributes)
 
-    def apply_function_to_routes(self, function, location: str):
-        """
-        Applies a function or mapping to Routes within the Schedule. Fails silently, if the keys referred to by the
-        function are not present, they will not be considered. The function will only be applied where it is possible.
-        :param function: function, a callable, of Route attributes dictionary returning a value that should be stored
-            under `location` or a dictionary mapping - in the case of a dictionary all values stored under `location`
-            will be mapped to new values given by the mapping, if they are present.
-        :param location: where to save the results: string defining the key in the Route attributes dictionary
-        :return:
+    def apply_function_to_routes(self, function: Callable, location: str):
+        """Applies a function or mapping to Routes within the Schedule.
+
+        Fails silently, if the keys referred to by the function are not present, they will not be considered.
+        The function will only be applied where it is possible.
+
+        Args:
+            function (Callable):
+                Function of Service attributes dictionary returning a value that should be stored under `location` or a dictionary mapping.
+                In the case of a dictionary all values stored under `location` will be mapped to new values given by the mapping, if they are present.
+
+            location (str): where to save the results: string defining the key in the Service attributes dictionary
         """
         new_attributes = graph_operations.apply_to_attributes(
             self._graph.graph["routes"].items(), function, location
         )
         self.apply_attributes_to_routes(new_attributes)
 
-    def apply_function_to_stops(self, function, location: str):
-        """
-        Applies a function or mapping to Stops within the Schedule. Fails silently, if the keys referred to by the
-        function are not present, they will not be considered. The function will only be applied where it is possible.
-        :param function: function, a callable, of Stop attributes dictionary returning a value that should be stored
-            under `location` or a dictionary mapping - in the case of a dictionary all values stored under `location`
-            will be mapped to new values given by the mapping, if they are present.
-        :param location: where to save the results: string defining the key in the Stop attributes dictionary
-        :return:
+    def apply_function_to_stops(self, function: Callable, location: str):
+        """Applies a function or mapping to Stops within the Schedule.
+
+        Fails silently, if the keys referred to by the function are not present, they will not be considered.
+        The function will only be applied where it is possible.
+
+        Args:
+            function (Callable):
+                Function of Service attributes dictionary returning a value that should be stored under `location` or a dictionary mapping.
+                In the case of a dictionary all values stored under `location` will be mapped to new values given by the mapping, if they are present.
+
+            location (str): where to save the results: string defining the key in the Service attributes dictionary
         """
         new_attributes = graph_operations.apply_to_attributes(
             self._graph.nodes(data=True), function, location
@@ -2973,27 +3067,31 @@ class Schedule(ScheduleElement):
                 stops_without_data.append(stop)
         return stops_without_data, stops_with_conflicting_data
 
-    def add_service(self, service: Service, force=False):
-        """
-        Adds a service to Schedule.
-        :param service: genet.Service object, must have index unique w.r.t. Services already in the Schedule
-        :param force: force the add, even if the stops in the Service have data conflicting with the stops of the same
-            IDs that are already in the Schedule. This will force the Service to be added, the stops data of currently
-            in the Schedule will persist. If you want to change the data for stops use `apply_attributes_to_stops` or
-            `apply_function_to_stops`.
-        :return:
+    def add_service(self, service: Service, force: bool = False):
+        """Adds a service to Schedule.
+
+        Args:
+            service (Service): genet.Service object, must have index unique w.r.t. Services already in the Schedule.
+            force (bool, optional):
+                force the add, even if the stops in the Service have data conflicting with the stops of the same IDs that are already in the Schedule.
+                This will force the Service to be added, the stops data of currently in the Schedule will persist.
+                If you want to change the data for stops use `apply_attributes_to_stops` or `apply_function_to_stops`.
+                Defaults to False.
         """
         self.add_services(services=[service], force=force)
 
-    def add_services(self, services: List[Service], force=False):
-        """
-        Adds multiple services to Schedule.
-        :param service: genet.Service object, must have index unique w.r.t. Services already in the Schedule
-        :param force: force the add, even if the stops in the Service have data conflicting with the stops of the same
-            IDs that are already in the Schedule. This will force the Service to be added, the stops data of currently
-            in the Schedule will persist. If you want to change the data for stops use `apply_attributes_to_stops` or
-            `apply_function_to_stops`.
-        :return:
+    def add_services(self, services: list[Service], force: bool = False) -> list[Service]:
+        """Adds multiple services to Schedule.
+
+        Args:
+            services (list[Service]): genet.Service objects, must have index unique w.r.t. Services already in the Schedule.
+            force (bool, optional):
+                force the add, even if the stops in the Service have data conflicting with the stops of the same IDs that are already in the Schedule.
+                This will force the Service to be added, the stops data of currently in the Schedule will persist.
+                If you want to change the data for stops use `apply_attributes_to_stops` or `apply_function_to_stops`.
+                Defaults to False.
+        Returns:
+            list[Service]: `service` with graph updates.
         """
         clashing_ids = []
         for service in services:
@@ -3065,18 +3163,18 @@ class Schedule(ScheduleElement):
         return services
 
     def remove_service(self, service_id: str):
-        """
-        Removes Service under given index `service_id`
-        :param service_id: Service ID to remove
-        :return:
+        """Removes Service under given index `service_id`.
+
+        Args:
+            service_id (str): Service ID to remove.
         """
         self.remove_services(service_ids=[service_id])
 
-    def remove_services(self, service_ids: List[str]):
-        """
-        Removes Services with given indices
-        :param service_ids: List of service IDs to remove
-        :return:
+    def remove_services(self, service_ids: list[str]):
+        """Removes Services with given indices.
+
+        Args:
+            service_ids (list[str]): List of service IDs to remove.
         """
         service_ids = persistence.listify(service_ids)
         missing_ids = []
@@ -3124,28 +3222,30 @@ class Schedule(ScheduleElement):
         }
         logging.info(f"Removed Services with IDs `{service_id}`, and Routes: {route_ids}")
 
-    def add_route(self, service_id, route: Route, force=False):
-        """
-        Adds route to a service already in the Schedule.
-        :param service_id: service id in the Schedule to add the route to
-        :param route: Route object to add
-        :param force: force the add, even if the stops in the Route have data conflicting with the stops of the same
-            IDs that are already in the Schedule. This will force the Route to be added, the stops data of currently
-            in the Schedule will persist. If you want to change the data for stops use `apply_attributes_to_stops` or
-            `apply_function_to_stops`.
-        :return:
+    def add_route(self, service_id: Union[str, int], route: Route, force: bool = False):
+        """Adds route to a service already in the Schedule.
+
+        Args:
+            service_id (Union[str, int]): service id in the Schedule to add the route to.
+            route (Route): Route object to add.
+            force (bool, optional):
+                force the add, even if the stops in the Service have data conflicting with the stops of the same IDs that are already in the Schedule.
+                This will force the Service to be added, the stops data of currently in the Schedule will persist.
+                If you want to change the data for stops use `apply_attributes_to_stops` or `apply_function_to_stops`.
+                Defaults to False.
         """
         self.add_routes(routes_dict={service_id: [route]}, force=force)
 
-    def add_routes(self, routes_dict: Dict[str, List[Route]], force=False):
-        """
-        Adds routes to services already present in the Schedule.
-        :param routes_dict: dictionary specifying service IDs and list of routes (Route objects) to add to them
-        :param force: force the add, even if the stops in the Route have data conflicting with the stops of the same
-            IDs that are already in the Schedule. This will force the Route to be added, the stops data of currently
-            in the Schedule will persist. If you want to change the data for stops use `apply_attributes_to_stops` or
-            `apply_function_to_stops`.
-        :return:
+    def add_routes(self, routes_dict: dict[str, list[Route]], force: bool = False):
+        """Adds routes to services already present in the Schedule.
+
+        Args:
+            routes_dict (dict[str, list[Route]]): dictionary specifying service IDs and list of routes (Route objects) to add to them.
+            force (bool, optional):
+                force the add, even if the stops in the Service have data conflicting with the stops of the same IDs that are already in the Schedule.
+                This will force the Service to be added, the stops data of currently in the Schedule will persist.
+                If you want to change the data for stops use `apply_attributes_to_stops` or `apply_function_to_stops`.
+                Defaults to False.
         """
         missing_services = []
         route_ids = []
@@ -3226,19 +3326,20 @@ class Schedule(ScheduleElement):
         self.generate_vehicles(overwrite=False)
         return routes_dict
 
-    def remove_route(self, route_id):
-        """
-        Removes Route under index `route_id`
-        :param route_id: route ID to remove
-        :return:
+    def remove_route(self, route_id: str):
+        """Removes Route under index `route_id`.
+
+        Args:
+            route_id (str): route ID to remove
+
         """
         self.remove_routes(route_ids=[route_id])
 
-    def remove_routes(self, route_ids: List[str]):
-        """
-        Removes Route under index `route_id`
-        :param route_ids: list of route IDs to remove
-        :return:
+    def remove_routes(self, route_ids: list[str]):
+        """Removes Route under index `route_id`.
+
+        Args:
+            route_ids (list[str]): route IDs to remove.
         """
         route_ids = persistence.listify(route_ids)
         missing_ids = []
@@ -3310,10 +3411,10 @@ class Schedule(ScheduleElement):
         logging.info(f"Removed Routes with IDs {route_ids}, to Services `{service_id}`.")
 
     def remove_stop(self, stop_id: str):
-        """
-        Removes Stop under index `stop_id`
-        :param stop_id:
-        :return:
+        """Removes Stop under index `stop_id`.
+
+        Args:
+            stop_id (str): Stop ID to remove.
         """
         self.remove_stops([stop_id])
 
@@ -3375,10 +3476,11 @@ class Schedule(ScheduleElement):
         if stops_to_remove:
             self.remove_stops(stops_to_remove)
 
-    def has_trips_with_zero_headways(self):
-        """
-        Deletes trips that have zero headways and thus deemed duplicates
-        :return:
+    def has_trips_with_zero_headways(self) -> bool:
+        """Deletes trips that have zero headways and thus deemed duplicates.
+
+        Returns:
+            bool: True if any trips have zero headway.
         """
         trip_headways_df = self.trips_headways()
         zero_headways = trip_headways_df[(trip_headways_df["headway_mins"] == 0)]
@@ -3387,7 +3489,6 @@ class Schedule(ScheduleElement):
     def fix_trips_with_zero_headways(self):
         """
         Deletes trips that have zero headways and thus deemed duplicates
-        :return:
         """
         trip_headways_df = self.trips_headways()
         zero_headways = trip_headways_df[(trip_headways_df["headway_mins"] == 0)]
@@ -3522,15 +3623,19 @@ class Schedule(ScheduleElement):
     def generate_validation_report(self):
         return schedule_validation.generate_validation_report(schedule=self)
 
-    def generate_standard_outputs(self, output_dir, gtfs_day="19700101", include_shp_files=False):
-        """
-        Generates geojsons that can be used for generating standard kepler visualisations.
-        These can also be used for validating network for example inspecting link capacity, freespeed, number of lanes,
-        the shape of modal subgraphs.
-        :param output_dir: path to folder where to save resulting geojsons
-        :param gtfs_day: day in format YYYYMMDD for the network's schedule for consistency in visualisations,
-        defaults to 1970/01/01 otherwise
-        :return: None
+    def generate_standard_outputs(
+        self, output_dir: str, gtfs_day: str = "19700101", include_shp_files: bool = False
+    ):
+        """Generates geojsons that can be used for generating standard kepler visualisations.
+
+        These can also be used for validating network for example inspecting link capacity, freespeed, number of lanes, the shape of modal subgraphs.
+
+        Args:
+            output_dir (str): path to folder where to save resulting geojsons.
+            gtfs_day (str, optional):
+                Day in format YYYYMMDD for the network's schedule for consistency in visualisations,
+                Defaults to "19700101" (1970-01-01).
+            include_shp_files (bool, optional): If True, also store shapefiles. Defaults to False.
         """
         gngeojson.generate_standard_outputs_for_schedule(
             self, output_dir, gtfs_day, include_shp_files
@@ -3538,13 +3643,15 @@ class Schedule(ScheduleElement):
         logging.info("Finished generating standard outputs. Zipping folder.")
         persistence.zip_folder(output_dir)
 
-    def write_to_matsim(self, output_dir, reproj_processes=1):
-        """
-        Save to MATSim XML format.
-        :param output_dir: path to output directory
-        :param reproj_processes: you can set this in case you have a lot of stops and your stops need to be reprojected
-            it splits the process across given number of processes.
-        :return:
+    def write_to_matsim(self, output_dir: str, reproj_processes: int = 1):
+        """Save to MATSim XML format.
+
+        Args:
+            output_dir (str): path to output directory.
+            reproj_processes (int, optional):
+                You can set this in case you have a lot of stops and your stops need to be reprojected.
+                It splits the process across given number of processes.
+                Defaults to 1.
         """
         persistence.ensure_dir(output_dir)
         matsim_xml_writer.write_matsim_schedule(output_dir, self, reproj_processes=reproj_processes)
@@ -3575,11 +3682,11 @@ class Schedule(ScheduleElement):
             "vehicles": {"vehicle_types": self.vehicle_types, "vehicles": self.vehicles},
         }
 
-    def write_to_json(self, output_dir):
-        """
-        Writes Schedule to a single JSON file with stops, services, vehicles and minimum transfer times (if applicable)
-        :param output_dir: output directory
-        :return:
+    def write_to_json(self, output_dir: str):
+        """Writes Schedule to a single JSON file with stops, services, vehicles and minimum transfer times (if applicable)
+
+        Args:
+            output_dir (str): output directory.
         """
         persistence.ensure_dir(output_dir)
         logging.info(f"Saving Schedule to JSON in {output_dir}")
@@ -3587,12 +3694,13 @@ class Schedule(ScheduleElement):
             json.dump(self.to_json(), outfile)
         self.write_extras(output_dir)
 
-    def write_to_geojson(self, output_dir, epsg):
-        """
-        Writes Schedule graph to nodes and edges geojson files.
-        :param output_dir: output directory
-        :param epsg: projection if the geometry is to be reprojected, defaults to own projection
-        :return:
+    def write_to_geojson(self, output_dir: str, epsg: str):
+        """Writes Schedule graph to nodes and edges geojson files.
+
+        Args:
+            output_dir (str): output directory.
+            epsg (str): projection if the geometry is to be reprojected, defaults to own projection.
+
         """
         persistence.ensure_dir(output_dir)
         _gdfs = self.to_geodataframe()
@@ -3610,22 +3718,27 @@ class Schedule(ScheduleElement):
         )
         self.write_extras(output_dir)
 
-    def to_gtfs(self, gtfs_day, mode_to_route_type: dict = None):
-        """
-        Transforms Schedule in to GTFS-like format. It's not full GTFS as it only represents one day, misses a lot
-         of optional data and does not include `agency.txt` required file. Produces 'stops', 'routes', 'trips',
-         'stop_times', 'calendar' tables.
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format
-        :param mode_to_route_type: PT modes in Route objects to route type code by default uses
-        https://developers.google.com/transit/gtfs/reference#routestxt
-        {
-            "tram": 0, "subway": 1, "rail": 2, "bus": 3, "ferry": 4, "cablecar": 5, "gondola": 6, "funicular": 7
-        }
-        Reference for extended mode types:
-        https://developers.google.com/transit/gtfs/reference/extended-route-types
+    def to_gtfs(self, gtfs_day: str, mode_to_route_type: Optional[dict] = None) -> dict:
+        """Transforms Schedule in to GTFS-like format.
 
-        :return: Dictionary, keys are the names of the tables e.g. `stops` for the `stops.txt` file, values are
-            pandas.DataFrame tables.
+        It's not full GTFS as it only represents one day, misses a lot of optional data and does not include `agency.txt` required file.
+        Produces 'stops', 'routes', 'trips', 'stop_times', 'calendar' tables.
+
+        Args:
+            gtfs_day (str): day used for GTFS when creating the network in YYYYMMDD format
+            mode_to_route_type (Optional[dict], optional):
+                PT modes in Route objects to route type code by default uses https://developers.google.com/transit/gtfs/reference#routestxt
+                Example:
+                ```python
+                {
+                    "tram": 0, "subway": 1, "rail": 2, "bus": 3, "ferry": 4, "cablecar": 5, "gondola": 6, "funicular": 7
+                }
+                ```
+                Reference for extended mode types:
+                https://developers.google.com/transit/gtfs/reference/extended-route-types.
+
+        Returns:
+            dict: keys are the names of the tables e.g. `stops` for the `stops.txt` file, values are pandas.DataFrame tables.
         """
         stops = self.stop_attribute_data(
             keys=[
@@ -3753,13 +3866,18 @@ class Schedule(ScheduleElement):
             "calendar": calendar,
         }
 
-    def write_to_csv(self, output_dir, gtfs_day="19700101", file_extention="csv"):
-        """
-        Writes 'stops', 'routes', 'trips', 'stop_times', 'calendar' tables to CSV files
-        :param output_dir: folder to output csv or txt files
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :param file_extention: csv by default, or txt
-        :return: None
+    def write_to_csv(
+        self,
+        output_dir: str,
+        gtfs_day: str = "19700101",
+        file_extention: Literal["csv", "txt"] = "csv",
+    ):
+        """Writes 'stops', 'routes', 'trips', 'stop_times', 'calendar' tables to CSV files.
+
+        Args:
+            output_dir (str): folder to output csv or txt files.
+            gtfs_day (str, optional): day used for GTFS when creating the network in YYYYMMDD format. Defaults to "19700101".
+            file_extention (Literal[csv, txt], optional): File extension to save to. Defaults to "csv".
         """
         persistence.ensure_dir(output_dir)
         logging.info(f"Saving Schedule to GTFS {file_extention} in {output_dir}")
@@ -3769,12 +3887,14 @@ class Schedule(ScheduleElement):
             df.to_csv(file_path)
         self.write_extras(output_dir)
 
-    def write_to_gtfs(self, output_dir, gtfs_day="19700101"):
-        """
-        Writes 'stops', 'routes', 'trips', 'stop_times', 'calendar' tables to CSV files
-        :param output_dir: folder to output txt files
-        :param gtfs_day: day used for GTFS when creating the network in YYYYMMDD format defaults to 19700101
-        :return: None
+    def write_to_gtfs(self, output_dir: str, gtfs_day: str = "19700101"):
+        """Writes 'stops', 'routes', 'trips', 'stop_times', 'calendar' tables to CSV files.
+
+        FIXME: Is this mixed up with `write_to_csv`?
+
+        Args:
+            output_dir (str): folder to output csv or txt files.
+            gtfs_day (str, optional): day used for GTFS when creating the network in YYYYMMDD format. Defaults to "19700101".
         """
         self.write_to_csv(output_dir, gtfs_day=gtfs_day, file_extention="txt")
 
@@ -3812,12 +3932,16 @@ class Schedule(ScheduleElement):
                     "access_tag": col,
                     "number_of_stops_with_access_tag": len(df[col].dropna()),
                     "unique_values_under_access_tag": set(df[col].dropna().unique()),
-                    "link_access_tag": network_access_tag
-                    if network_access_tag in df.columns
-                    else "not_connected_to_network",
-                    "number_of_stops_with_link_access_tag": len(df[network_access_tag].dropna())
-                    if network_access_tag in df.columns
-                    else 0,
+                    "link_access_tag": (
+                        network_access_tag
+                        if network_access_tag in df.columns
+                        else "not_connected_to_network"
+                    ),
+                    "number_of_stops_with_link_access_tag": (
+                        len(df[network_access_tag].dropna())
+                        if network_access_tag in df.columns
+                        else 0
+                    ),
                 }
         return report
 
@@ -3868,11 +3992,13 @@ def verify_graph_schema(graph):
                 )
 
 
-def read_vehicle_types(yml):
+def read_vehicle_types(yml: str) -> dict:
     """
-    :param yml: path to .yml file based on example vehicles config in `genet/configs/vehicles/vehicle_definitions.yml`
-        or a bytes stream of that file
-    :return:
+    Args:
+        yml (str): path to .yml file based on example vehicles config in `genet/configs/vehicles/vehicle_definitions.yml`.
+
+    Returns:
+        dict: Vehicle type dictionary.
     """
     if persistence.is_yml(yml):
         yml = io.open(yml, mode="r")
@@ -3885,11 +4011,12 @@ def get_headway(group):
 
 
 def generate_trip_departures_from_headway(headway_spec: dict):
-    """
-    Generates new trip departure times
-    :param headway_spec: dictionary with tuple keys: (from time, to time) and headway values in minutes
-     {('HH:MM:SS', 'HH:MM:SS'): headway_minutes}.
-    :return:
+    """Generates new trip departure times.
+
+    Args:
+        headway_spec (dict):
+            Dictionary with tuple keys: (from time, to time) and headway values in minutes:
+            `{('HH:MM:SS', 'HH:MM:SS'): headway_minutes}`.
     """
     trip_departures = set()
     for (from_time, to_time), headway_mins in headway_spec.items():

--- a/genet/schedule_elements.py
+++ b/genet/schedule_elements.py
@@ -3893,8 +3893,6 @@ class Schedule(ScheduleElement):
     def write_to_gtfs(self, output_dir: str, gtfs_day: str = "19700101"):
         """Writes 'stops', 'routes', 'trips', 'stop_times', 'calendar' tables to CSV files.
 
-        FIXME: Is this mixed up with `write_to_csv`?
-
         Args:
             output_dir (str): folder to output csv or txt files.
             gtfs_day (str, optional): day used for GTFS when creating the network in YYYYMMDD format. Defaults to "19700101".

--- a/genet/utils/graph_operations.py
+++ b/genet/utils/graph_operations.py
@@ -1,6 +1,6 @@
 import logging
 from itertools import count, filterfalse
-from typing import Callable, Dict, Iterable, Union
+from typing import Callable, Dict, Iterable, Optional, Union
 
 import pandas as pd
 from anytree import Node, RenderTree
@@ -54,9 +54,14 @@ class Filter:
 
     def __init__(
         self,
-        conditions: Union[
-            list,
-            Dict[str, Union[dict, Union[str, int, float], list, Callable[[str, int, float], bool]]],
+        conditions: Optional[
+            Union[
+                list,
+                Dict[
+                    str,
+                    Union[dict, Union[str, int, float], list, Callable[[str, int, float], bool]],
+                ],
+            ]
         ] = None,
         how=any,
         mixed_dtypes=True,
@@ -257,7 +262,9 @@ def get_attribute_data_under_key(iterator: Iterable, key: Union[str, dict]):
     return data
 
 
-def build_attribute_dataframe(iterator, keys: Union[list, str], index_name: str = None):
+def build_attribute_dataframe(
+    iterator, keys: Union[Iterable, str], index_name: Optional[str] = None
+):
     """
     Builds a pandas.DataFrame from data in iterator.
     :param iterator: iterator or list of tuples (id, dictionary data with keys of interest)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,82 @@
+site_name: Network Scenario Generator (GeNet)
+nav:
+  - Home: index.md
+  - installation.md
+  - docker.md
+  - Examples: [] # this will be filled in automatically to include reference to all the notebooks
+  - Contributing: contributing.md
+  - Changelog: CHANGELOG.md
+  - Reference:
+    - Command line interface: api/cli.md
+theme:
+  name: material
+  custom_dir: docs/overrides
+  features:
+    - navigation.indexes
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+repo_url: https://github.com/arup-group/genet/
+site_dir: .docs
+markdown_extensions:
+  - admonition
+  - attr_list
+  - mkdocs-click
+  - tables
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.snippets
+  - pymdownx.tasklist:
+      clickable_checkbox: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: "#"
+      toc_depth: 3
+hooks:
+  - docs/static/hooks.py
+plugins:
+  - search
+  - autorefs
+  - mkdocs-jupyter:
+      include: ["examples/*.ipynb"]
+      ignore: ["examples/.*/*.py"]
+      allow_errors: false
+      kernel_name: genet
+      include_source: True
+      execute: false
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            docstring_section_style: spacy
+            show_bases: true
+            filters:
+              - "!^_"
+            merge_init_into_class: true
+            show_if_no_docstring: true
+            signature_crossrefs: true
+            show_root_toc_entry: false
+            show_signature_annotations: false
+          import:
+            - https://docs.python.org/3/objects.inv
+            - https://pandas.pydata.org/docs/objects.inv
+            - https://docs.python.org/3/objects.inv
+            - https://shapely.readthedocs.io/en/stable/objects.inv
+            - https://geopandas.org/en/stable/objects.inv
+            - https://networkx.org/documentation/stable/objects.inv
+watch:
+  - genet
+extra_css:
+  - static/extras.css
+extra:
+  version:
+    provider: mike

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ output = "reports/coverage/coverage.xml"
 
 [tool.black]
 line-length = 100
-skip_magic_trailing_comma = true
+skip-magic-trailing-comma = true
 
 [tool.ruff]
 line-length = 100

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,13 @@
 jupyter < 2
+mike >= 2, < 3
+mkdocs < 2
+mkdocs-material >= 9.4, < 10
+mkdocs-click < 0.7
+mkdocs-jupyter < 0.25
+mkdocstrings-python < 2
 nbmake < 2
 pre-commit < 4
-pytest < 8
+pytest >= 8, < 9
 pytest-cov < 5
 pytest-mock < 4
 pytest-timeout < 3


### PR DESCRIPTION
Move to github pages for the docs. 

This will render all the example notebooks and display them, so none of that information is lost from the wiki.

I've also moved most of the installation instructions to the docs and given use of Docker its own page.

I got about 60% of the way through updating the docstrings, but it is mind-numbing stuff so I focussed on the most important classes. I also updated type hinting as I was going along. 

Why update docstrings? If docstrings are set up correctly then when rendering the docs, it will pick up on inconsistencies between the function signature and the docstrings, so you can catch issues where you've updated your function sig but not your docstring. Also, I see lots of complaints from mypy now that I've updated type hinting enough for it to kick in (it tends not to bother if you haven't put in enough hints). 

So 99.9% the changes to the source code in this PR are just to docstrings and type hints. I did also move around some abstract methods of ScheduleElements and made it an actual abstract class (until now `@abstractmethod` decorator wasn't doing anything), but tests still pass locally so I'm hoping that hasn't broken anything ;)
