### PR TITLE
Add xarray with version pinning to requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,4 +25,5 @@ s2sphere < 0.3
 scikit-learn >= 1.2, < 2
 shapely >= 1, < 3
 tqdm >= 4, < 5
+xarray <= 2024.2
 xmltodict < 0.14


### PR DESCRIPTION
Noticed a failing test in https://github.com/arup-group/genet/actions/runs/8471718196/job/23332569549?pr=232. It is caused by xarray [v2024.03](https://docs.xarray.dev/en/stable/whats-new.html#v2024-03-0-mar-29-2024) having the `.oindex` property which seems to be causing issues with our test's array comparison. This is fixed by pinning xarray.