### PR TITLE
Update docs and template

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/arup-group/cookiecutter-pypackage",
-  "commit": "fdc37ca81ad3f267199b04856722ea68648b9109",
+  "commit": "b7724521f898ab28f541d492aff8e2be2ed76a01",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To install genet (indexed online as cml-genet), we recommend using the [mamba](h
 ``` shell
 git clone git@github.com:arup-group/genet.git
 cd genet
-mamba create -n genet -c conda-forge --file requirements/base.txt
+mamba create -n genet -c conda-forge -c city-modelling-lab --file requirements/base.txt
 mamba activate genet
 pip install --no-deps .
 ```
@@ -84,7 +84,7 @@ For more information, see our [documentation](https://arup-group.github.io/genet
 ``` shell
 git clone git@github.com:arup-group/genet.git
 cd genet
-mamba create -n genet -c conda-forge --file requirements/base.txt --file requirements/dev.txt
+mamba create -n genet -c conda-forge -c city-modelling-lab --file requirements/base.txt --file requirements/dev.txt
 mamba activate genet
 pip install --no-deps -e .
 ipython kernel install --user --name=genet

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,7 +34,7 @@ To create a development environment for genet, with all libraries required for d
 2. Open the command line (or the "miniforge prompt" in Windows).
 3. Download (a.k.a., clone) the genet repository: `git clone git@github.com:arup-group/genet.git`
 4. Change into the `genet` directory: `cd genet`
-5. Create the genet mamba environment: `mamba create -n genet -c conda-forge --file requirements/base.txt --file requirements/dev.txt`
+5. Create the genet mamba environment: `mamba create -n genet -c conda-forge -c city-modelling-lab --file requirements/base.txt --file requirements/dev.txt`
 6. Activate the genet mamba environment: `mamba activate genet`
 7. Install the cml-genet package into the environment, in editable mode and ignoring dependencies (we have dealt with those when creating the mamba environment): `pip install --no-deps -e .`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,7 +47,7 @@ jupyter notebook
 If you would like to use a different name to `genet` for your mamba environment, the installation becomes (where `[my-env-name]` is your preferred name for the environment):
 
 ``` shell
-mamba create -n [my-env-name] -c conda-forge --file requirements/base.txt
+mamba create -n [my-env-name] -c conda-forge -c city-modelling-lab --file requirements/base.txt
 mamba activate [my-env-name]
 ipython kernel install --user --name=[my-env-name]
 ```

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,10 @@
 cruft >= 2, < 3
 jupyter < 2
 mike >= 2, < 3
-mkdocs < 2
+mkdocs < 1.6
 mkdocs-material >= 9.4, < 10
 mkdocs-click < 0.7
-mkdocs-jupyter < 0.25
+mkdocs-jupyter < 0.24.7
 mkdocstrings-python < 2
 nbmake >= 1.5.1, < 2
 pre-commit < 4


### PR DESCRIPTION
Fixes #239 by adding `-c city-modelling-lab` to the docs install instructions (incl. README).
Fixes broken CI in #232 by updating dev requirements from latest template changes. 