### PR TITLE
Bugfix: Multi-indexing fails in a very specific case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Issue when adding edges to fill spaces left by removing other edges (failure in resolving multi indexing) [#248](https://github.com/arup-group/genet/issues/248)
 * Fixed generating standard outputs by highway tag which were broken after moving to storing additional attributes in short form [#217](https://github.com/arup-group/genet/pull/217)
 * Fixed summary report:
   * Intermodal Access/Egress reporting is more general (not expecting just car and bike mode access to PT) [#204](https://github.com/arup-group/genet/pull/204)

--- a/src/genet/core.py
+++ b/src/genet/core.py
@@ -1308,6 +1308,7 @@ class Network:
                 df_links[df_links["id"].isin(clashing_multi_idxs)]
                 .groupby(["from", "to"])
                 .apply(generate_unique_multi_idx)
+                .set_index("id", drop=False)
             )
 
             # generate unique indices if not

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -1938,7 +1938,7 @@ def test_adding_multiple_links_with_id_and_multi_idx_clashes(assert_semantically
     )
 
 
-def test_adding_many_links_with_id_and_multi_idx_clashes(assert_semantically_equal, mocker):
+def test_avoids_destructive_index_clashes_when_adding_replacement_links(mocker):
     n = Network("epsg:27700")
     for i in range(3):
         n.add_link(str(i), 1, 2)
@@ -1954,8 +1954,11 @@ def test_adding_many_links_with_id_and_multi_idx_clashes(assert_semantically_equ
     reindexing_dict, links_and_attribs = n.add_links(links_to_add)
 
     assert (
+        len(list(n.links())) == 5
+    ), "Network does not have the expected number of links: 5 = (3 original - 1 removed) + 3 new links"
+    assert (
         len({v["multi_edge_idx"] for v in n.link_id_mapping.values()}) == 5
-    ), "Some multiindices were not unique"
+    ), "Some multi-indices are not unique"
 
 
 def test_adding_multiple_links_missing_some_from_nodes():

--- a/tests/test_core_network.py
+++ b/tests/test_core_network.py
@@ -1958,7 +1958,7 @@ def test_avoids_destructive_index_clashes_when_adding_replacement_links(mocker):
     ), "Network does not have the expected number of links: 5 = (3 original - 1 removed) + 3 new links"
     assert (
         len({v["multi_edge_idx"] for v in n.link_id_mapping.values()}) == 5
-    ), "Some multi-indices are not unique"
+    ), "Some multi-indices are not unique, the number of multi-indeces should match the number of links"
 
 
 def test_adding_multiple_links_missing_some_from_nodes():


### PR DESCRIPTION
Fixes: #248, in a wild turn of events, my projected 3 part PR series has grown to 4. I found this bug while working on #245. The fix is inversely proportional to the amount of time it took to diagnose and recreate the issue in a unit test..

I had to mock the method which gives the available multi-index for an edge in the graph because it would not give me the same behaviour as I was seeing with a larger dataset. The problem happens when this method outputs an available multi-index that is sandwiched by multi-indices already being used on the graph. In this small example it would always give me the largest index being used +1, which did not recreate the error.

Stripped from all the context, the problem was setting a dataframe with an output of a groupby (of the same dataframe) which has inherited indexing from the groupby operation. This did not match the indexing of the original dataframe, so when trying to set it back in, it resulted in loss of data. 