### PR TITLE
Remove references to mamba from CI workflows

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -16,7 +16,7 @@
       "project_visibility": "public",
       "upload_pip_package": "n",
       "upload_conda_package": "y",
-      "upload_aws_image": "n",
+      "upload_aws_image": "y",
       "conda_channel": "city-modelling-lab",
       "command_line_interface": "y",
       "create_docker_file": "y",

--- a/.cruft.json
+++ b/.cruft.json
@@ -13,6 +13,7 @@
       "package_name": "cml-genet",
       "module_name": "genet",
       "project_short_description": "GeNet provides tools to represent and work with a multi-modal transport network with public transport (PT) services",
+      "project_visibility": "public",
       "upload_pypi_package": "y",
       "upload_conda_package": "y",
       "upload_aws_image": "n",

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/arup-group/cookiecutter-pypackage",
-  "commit": "bb2bab415eded9682b2c1d465a281450ec922f1c",
+  "commit": "2c07547902fe10839dcfb8031ef612bf7ca4f23f",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -14,7 +14,7 @@
       "module_name": "genet",
       "project_short_description": "GeNet provides tools to represent and work with a multi-modal transport network with public transport (PT) services",
       "project_visibility": "public",
-      "upload_pypi_package": "y",
+      "upload_pip_package": "n",
       "upload_conda_package": "y",
       "upload_aws_image": "n",
       "conda_channel": "city-modelling-lab",
@@ -24,7 +24,8 @@
       "create_jupyter_notebook_directory": "y",
       "check_docs_accessibility_in_CI": "n",
       "open_source_license": "MIT license",
-      "_template": "https://github.com/arup-group/cookiecutter-pypackage"
+      "_template": "https://github.com/arup-group/cookiecutter-pypackage",
+      "_commit": "2c07547902fe10839dcfb8031ef612bf7ca4f23f"
     }
   },
   "directory": null

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Documentation: https://EditorConfig.org
+# Inspired by Calliope .editorconfig file
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[LICENSE]
+insert_final_newline = false

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.0
     with:
       os: ubuntu-latest
       py3version: "12"

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -20,7 +20,7 @@ jobs:
       py3version: "12"
       notebook_kernel: genet
       lint: false
-      additional_mamba_args: coin-or-cbc
+      additional_env_create_args: coin-or-cbc
 
   aws-upload:
     needs: test

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -25,7 +25,7 @@ jobs:
   aws-upload:
     needs: test
     if: needs.test.result == 'success'
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@v1.1.1
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -19,10 +19,10 @@ jobs:
       py3version: "12"
       notebook_kernel: genet
       pytest_args: '--no-cov'  # ignore coverage
-      cache_mamba_env: false
+      cache_env: false
       lint: false
-      mamba_env_name: daily-ci
-      additional_mamba_args: coin-or-cbc
+      env_name: daily-ci
+      additional_env_create_args: coin-or-cbc
 
   slack-notify-ci:
     needs: test

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
     needs: get-date
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.1
     with:
       os: ubuntu-latest
       py3version: "12"
@@ -27,7 +27,7 @@ jobs:
   slack-notify-ci:
     needs: test
     if: always()
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@v1.1.1
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,9 +15,28 @@ on:
 
 
 jobs:
-  docs-test:
+  docs-lint:
     if: github.ref != 'refs/heads/main'
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: markdown-link-check
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: linkcheck.json
+    - if: github.event.repository.private
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: pymarkdown --all-files
+    - if: github.event.repository.private
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: codespell --all-files
+
+  docs-test:
+    needs: [docs-lint]
+    if: github.ref != 'refs/heads/main'
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.0
     with:
       deploy_type: test
       notebook_kernel: genet
@@ -26,7 +45,7 @@ jobs:
     permissions:
       contents: write
     if: github.ref == 'refs/heads/main'
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.0
     with:
       deploy_type: update_latest
       notebook_kernel: genet

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -43,7 +43,7 @@ jobs:
       lint: false
       pytest_args: '--no-cov'  # ignore coverage
       upload_to_codecov: false
-      additional_mamba_args: ${{ matrix.add_args }}
+      additional_env_create_args: ${{ matrix.add_args }}
 
   test-coverage:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
@@ -54,7 +54,7 @@ jobs:
       lint: false
       pytest_args: 'tests/'  # ignore example notebooks
       upload_to_codecov: true
-      additional_mamba_args: coin-or-cbc
+      additional_env_create_args: coin-or-cbc
 
   cruft-check:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/template-check.yml@main

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -35,7 +35,7 @@ jobs:
           - os: macos-latest
             add_args: coin-or-cbc
       fail-fast: false
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.0
     with:
       os: ${{ matrix.os }}
       py3version: ${{ matrix.py3version }}
@@ -46,7 +46,7 @@ jobs:
       additional_env_create_args: ${{ matrix.add_args }}
 
   test-coverage:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.0
     with:
       os: ubuntu-latest
       py3version: "12"
@@ -57,4 +57,4 @@ jobs:
       additional_env_create_args: coin-or-cbc
 
   cruft-check:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/template-check.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/template-check.yml@v1.1.0

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   conda-build:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@v1.1.1
     secrets:
       ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
     with:
@@ -15,7 +15,7 @@ jobs:
       package_name: cml-genet
 
   pip-build:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-build.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-build.yml@v1.1.1
     secrets:
       TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   conda-upload:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@v1.1.1
     secrets:
       ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
     with:
@@ -15,7 +15,7 @@ jobs:
       build_workflow: pre-release.yml
 
   pip-upload:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-upload.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-upload.yml@v1.1.1
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     with:
@@ -26,7 +26,7 @@ jobs:
   docs-stable:
     permissions:
       contents: write
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.1
     with:
       deploy_type: update_stable
       notebook_kernel: genet

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,12 @@ repos:
         language: fail
         files: "\\.rej$"
 
-ci:  # https://pre-commit.ci/
+      - id: version-without-v
+        name: Don't commit if package version is prepended with a `v`
+        entry: '__version__ = \"v'
+        language: pygrep
+        types: [text]
+
+ci: # https://pre-commit.ci/
   autofix_prs: false
   autoupdate_schedule: monthly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,12 @@ When opening a pull request, please provide a clear summary of your changes!
 
 Please try to write clear commit messages. One-line messages are fine for small changes, but bigger changes should look like this:
 
-    A brief summary of the commit (max 50 characters)
+```text
+A brief summary of the commit (max 50 characters)
 
-    A paragraph or bullet-point list describing what changed and its impact,
-    covering as many lines as needed.
+A paragraph or bullet-point list describing what changed and its impact,
+covering as many lines as needed.
+```
 
 ### Code conventions
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,7 +76,7 @@ pytest tests/ --no-cov
 ## Updating the project when the template updates
 
 This project has been built with [cruft](https://cruft.github.io/cruft/) based on the [Arup Cookiecutter template](https://github.com/arup-group/cookiecutter-pypackage).
-When changes are made to the base template, they can be merged into this project by running `cruft update` from the  `genet` mamba environment.
+When changes are made to the base template, they can be merged into this project by running `cruft update` from the  `genet` conda environment.
 
 You may be prompted to do this when you open a Pull Request, if our automated checks identify that the template is newer than that used in the project.
 

--- a/linkcheck.json
+++ b/linkcheck.json
@@ -1,0 +1,17 @@
+{
+    "ignorePatterns": [
+      {
+        "pattern": "^https://github.com/arup-group"
+      },
+      {
+        "pattern": "^https://arup.sharepoint.com"
+      },
+      {
+        "pattern": "^https://arup-my.sharepoint.com"
+      },
+      {
+        "pattern": "^https://aws.arup.com"
+      },
+    ]
+
+}


### PR DESCRIPTION
- Fixes #256 

I used `cruft update` to pull in the latest versions of the Actions workflows that are managed by the cookie-cutter template.

## Before
[Daily CI build failed](https://github.com/arup-group/genet/actions/runs/14086145639)

<img width="1695" alt="Screenshot 2025-03-26 at 18 44 00" src="https://github.com/user-attachments/assets/16581f75-b283-4c97-a97a-75e5741f162d" />

## After

[Commit CI build succeeded](https://github.com/arup-group/genet/actions/runs/14091043334/job/39467520415)

<img width="1687" alt="Screenshot 2025-03-26 at 18 50 36" src="https://github.com/user-attachments/assets/a0418d1c-59b7-4c01-acb2-57dace9f9e0e" />


## Looking for remaining references to Mamba in CI builds
```
(genet-conda-env) (genet-3.11.2) √ .github % pwd
/Users/mickyfitz/workspace/genet/.github

(genet-conda-env) (genet-3.11.2) √ .github % grep -iRn "mamba" .
(genet-conda-env) (genet-3.11.2) ?1 .github %
```