### PR TITLE
Fix broken git tags in CI workflows

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -25,7 +25,7 @@ jobs:
   aws-upload:
     needs: test
     if: needs.test.result == 'success'
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@v1.1.0
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
     needs: get-date
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.0
     with:
       os: ubuntu-latest
       py3version: "12"
@@ -27,7 +27,7 @@ jobs:
   slack-notify-ci:
     needs: test
     if: always()
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@v1.1.0
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   conda-build:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@v1.1.0
     secrets:
       ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
     with:
@@ -15,7 +15,7 @@ jobs:
       package_name: cml-genet
 
   pip-build:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-build.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-build.yml@v1.1.0
     secrets:
       TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   conda-upload:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@v1.1.0
     secrets:
       ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
     with:
@@ -15,7 +15,7 @@ jobs:
       build_workflow: pre-release.yml
 
   pip-upload:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-upload.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-upload.yml@v1.1.0
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     with:
@@ -26,7 +26,7 @@ jobs:
   docs-stable:
     permissions:
       contents: write
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.0
     with:
       deploy_type: update_stable
       notebook_kernel: genet


### PR DESCRIPTION
- Fixes #256  

So, the PR I merged to fix the builds used the wrong git tag for some of the actions (`v1.1.1` doesn't exist; we need `v1.1.0` - see [here](https://github.com/arup-group/actions-city-modelling-lab/tags)). Unfortunately, one of the places where the tag was correct was (part of) the CI commit workflow, so the build was fixed for that workflow but broken for the Daily CI, so we only discovered it was broken after merging:

<img width="1410" alt="Screenshot 2025-03-31 at 13 07 40" src="https://github.com/user-attachments/assets/f5fc08aa-223e-4bf8-8764-d7ddf9355145" />



# Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Tests added to cover contribution
- [x] Documentation updated
