### PR TITLE
Add DeepWiki badge and link to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # Network Scenario Generator (GeNet)
 
 [![DOI](https://zenodo.org/badge/265256468.svg)](https://zenodo.org/badge/latestdoi/265256468)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/arup-group/genet)
 
 GeNet provides tools to represent and work with a multi-modal transport network with public transport (PT)
 services. It is based on [MATSim's](https://www.matsim.org/) representation of such networks.
@@ -32,7 +33,9 @@ You can also write your own python scripts, importing genet as a package, use IP
 
 ## Documentation
 
-For more detailed instructions, see our [documentation](https://arup-group.github.io/genet/latest).
+For more detailed instructions, see our [documentation](https://arup-group.github.io/genet/latest). We also
+autogenerate queryable documentation using [DeepWiki](https://deepwiki.com/); you can find that
+[here](https://deepwiki.com/arup-group/genet).
 
 ## Installation
 


### PR DESCRIPTION
- Closes #262 

You can see the rendered new version of the README [here](https://github.com/arup-group/genet/blob/add-deepwiki-badge-to-readme/README.md). The new sections look like this:

### 1. DeepWiki Badge (it's also a hyperlink to the generated docs)
<img width="783" alt="Screenshot 2025-05-15 at 17 46 49" src="https://github.com/user-attachments/assets/d969755b-559e-433a-9455-c283eeb69d10" />
 
 
 ### 2. DeepWiki Link
<img width="1323" alt="Screenshot 2025-05-15 at 17 46 56" src="https://github.com/user-attachments/assets/81fb6dc7-ef12-4e4a-bf8f-95bde1db5af2" />